### PR TITLE
Improve scene beat editor

### DIFF
--- a/src/main/python/plotlyst/core/domain.py
+++ b/src/main/python/plotlyst/core/domain.py
@@ -450,6 +450,7 @@ class SceneStructureItem:
     part: int = 1
     text: str = ''
     outcome: Optional[SceneOutcome] = None
+    emotion: Optional[int] = None
 
 
 @dataclass

--- a/src/main/python/plotlyst/view/common.py
+++ b/src/main/python/plotlyst/view/common.py
@@ -153,7 +153,7 @@ class OpacityEventFilter(QObject):
 
     @overrides
     def eventFilter(self, watched: QObject, event: QEvent) -> bool:
-        if self.ignoreCheckedButton and self._checkedButton(watched):
+        if self.ignoreCheckedButton and self._checkedButton(watched) or not watched.isEnabled():
             return super(OpacityEventFilter, self).eventFilter(watched, event)
         if event.type() == QEvent.Enter:
             opaque(watched, self.enterOpacity)

--- a/src/main/python/plotlyst/view/common.py
+++ b/src/main/python/plotlyst/view/common.py
@@ -28,7 +28,7 @@ from PyQt5.QtCore import Qt, QRectF, QModelIndex, QRect, QPoint, QObject, QEvent
 from PyQt5.QtGui import QPixmap, QPainterPath, QPainter, QFont, QColor, QIcon, QDrag
 from PyQt5.QtWidgets import QWidget, QSizePolicy, QColorDialog, QAbstractItemView, \
     QMenu, QAction, QAbstractButton, \
-    QStackedWidget, QAbstractScrollArea, QLineEdit
+    QStackedWidget, QAbstractScrollArea, QLineEdit, QHeaderView
 from fbs_runtime import platform
 from overrides import overrides
 from qthandy import opaque
@@ -280,3 +280,11 @@ def icon_to_html_img(icon: QIcon, size: int = 20) -> str:
 
 def pointy(widget):
     widget.setCursor(Qt.PointingHandCursor)
+
+
+def autoresize_col(view: QAbstractItemView, col: int):
+    view.horizontalHeader().setSectionResizeMode(col, QHeaderView.ResizeToContents)
+
+
+def stretch_col(view: QAbstractItemView, col: int):
+    view.horizontalHeader().setSectionResizeMode(col, QHeaderView.Stretch)

--- a/src/main/python/plotlyst/view/report/character.py
+++ b/src/main/python/plotlyst/view/report/character.py
@@ -159,7 +159,6 @@ class CharacterArcChart(BaseChart):
         super().__init__(parent)
         self.novel = novel
         self.createDefaultAxes()
-        self.legend().hide()
         self.axis: Optional[QValueAxis] = None
 
     def refresh(self, character: Character):

--- a/src/main/python/plotlyst/view/scene_editor.py
+++ b/src/main/python/plotlyst/view/scene_editor.py
@@ -67,6 +67,7 @@ class SceneEditor(QObject):
             self._emoji_font = emoji_font(20)
 
         self.ui.btnAttributes.setOrientation(RotatedButtonOrientation.VerticalBottomToTop)
+        self.ui.btnAttributes.setIcon(IconRegistry.from_name('fa5s.yin-yang'))
         self.ui.btnNotes.setOrientation(RotatedButtonOrientation.VerticalBottomToTop)
         self.ui.btnNotes.setIcon(IconRegistry.document_edition_icon())
         self.ui.btnBuilder.setOrientation(RotatedButtonOrientation.VerticalBottomToTop)

--- a/src/main/python/plotlyst/view/widget/button.py
+++ b/src/main/python/plotlyst/view/widget/button.py
@@ -156,6 +156,20 @@ class FadeOutButtonGroup(QButtonGroup):
     def setFadeInDuration(self, duration: int):
         self._fadeInDuration = duration
 
+    def toggle(self, btn: QAbstractButton):
+        btn.setChecked(not btn.isChecked())
+        for other_btn in self.buttons():
+            if other_btn is btn:
+                continue
+
+            if btn.isChecked():
+                other_btn.setChecked(False)
+                other_btn.setDisabled(True)
+                other_btn.setHidden(True)
+            else:
+                other_btn.setEnabled(True)
+                other_btn.setVisible(True)
+
     def _clicked(self, btn: QAbstractButton):
         for other_btn in self.buttons():
             if other_btn is btn:
@@ -163,7 +177,9 @@ class FadeOutButtonGroup(QButtonGroup):
 
             if btn.isChecked():
                 other_btn.setChecked(False)
+                other_btn.setDisabled(True)
                 qtanim.fade_out(other_btn)
             else:
+                other_btn.setEnabled(True)
                 anim = qtanim.fade_in(other_btn, duration=self._fadeInDuration)
                 anim.finished.connect(partial(opaque, other_btn, self._opacity))

--- a/src/main/python/plotlyst/view/widget/button.py
+++ b/src/main/python/plotlyst/view/widget/button.py
@@ -56,12 +56,13 @@ class _SecondaryActionButton(QAbstractButton):
         super(_SecondaryActionButton, self).__init__(parent)
         self._iconName: str = ''
         self._iconColor: str = 'black'
+        self._checkedColor: str = 'black'
         self.initStyleSheet()
         self.setCursor(Qt.PointingHandCursor)
         self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Maximum)
         self.installEventFilter(OpacityEventFilter(leaveOpacity=0.7, parent=self))
 
-    def initStyleSheet(self, border_color: str = 'grey', border_color_checked: str = 'black'):
+    def initStyleSheet(self, border_color: str = 'grey'):
         self.setStyleSheet(f'''
                 {self.__class__.__name__} {{
                     border: 2px dashed {border_color};
@@ -73,7 +74,7 @@ class _SecondaryActionButton(QAbstractButton):
                     border: 2px solid {border_color};
                 }}
                 {self.__class__.__name__}:checked {{
-                    border: 2px solid {border_color_checked};
+                    border: 2px solid {self._checkedColor};
                 }}
             ''')
 
@@ -83,7 +84,7 @@ class _SecondaryActionButton(QAbstractButton):
 
     def _setIcon(self):
         if self._iconName:
-            self.setIcon(IconRegistry.from_name(self._iconName, self._iconColor))
+            self.setIcon(IconRegistry.from_name(self._iconName, self._iconColor, color_on=self._checkedColor))
 
 
 class SecondaryActionToolButton(QToolButton, _SecondaryActionButton):
@@ -105,6 +106,16 @@ class SecondaryActionToolButton(QToolButton, _SecondaryActionButton):
         self._iconColor = value
         self._setIcon()
 
+    @pyqtProperty(str)
+    def checkedColor(self):
+        return self._checkedColor
+
+    @checkedColor.setter
+    def checkedColor(self, value):
+        self._checkedColor = value
+        self.initStyleSheet()
+        self._setIcon()
+
 
 class SecondaryActionPushButton(QPushButton, _SecondaryActionButton):
     @pyqtProperty(str)
@@ -123,6 +134,16 @@ class SecondaryActionPushButton(QPushButton, _SecondaryActionButton):
     @iconColor.setter
     def iconColor(self, value):
         self._iconColor = value
+        self._setIcon()
+
+    @pyqtProperty(str)
+    def checkedColor(self):
+        return self._checkedColor
+
+    @checkedColor.setter
+    def checkedColor(self, value):
+        self._checkedColor = value
+        self.initStyleSheet()
         self._setIcon()
 
 

--- a/src/main/python/plotlyst/view/widget/chart.py
+++ b/src/main/python/plotlyst/view/widget/chart.py
@@ -20,12 +20,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from functools import partial
 from typing import List, Dict
 
-from PyQt5.QtChart import QChart, QPieSeries, QBarSet, QBarCategoryAxis, QValueAxis, QBarSeries
+from PyQt5.QtChart import QChart, QPieSeries, QBarSet, QBarCategoryAxis, QValueAxis, QBarSeries, QSplineSeries
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QColor, QCursor, QIcon
 from PyQt5.QtWidgets import QToolTip
 
-from src.main.python.plotlyst.core.domain import Character, MALE, FEMALE, TRANSGENDER, NON_BINARY, GENDERLESS, Novel
+from src.main.python.plotlyst.core.domain import Character, MALE, FEMALE, TRANSGENDER, NON_BINARY, GENDERLESS, Novel, \
+    SceneStructureItem
 from src.main.python.plotlyst.core.template import enneagram_choices, supporter_role, guide_role, sidekick_role, \
     antagonist_role, contagonist_role, adversary_role, henchmen_role, confidant_role, tertiary_role, SelectionItem, \
     secondary_role
@@ -41,6 +42,14 @@ class BaseChart(QChart):
         self.layout().setContentsMargins(0, 0, 0, 0)
         self.legend().hide()
         self.setBackgroundRoundness(0)
+
+    def reset(self):
+        if self.series():
+            self.removeAllSeries()
+        if self.axisX():
+            self.removeAxis(self.axisX())
+        if self.axisY():
+            self.removeAxis(self.axisY())
 
 
 class GenderCharacterChart(BaseChart):
@@ -208,12 +217,7 @@ class ManuscriptLengthChart(BaseChart):
         self.setTitle('<b>Manuscript length per chapters</b>')
 
     def refresh(self, novel: Novel):
-        if self.series():
-            self.removeAllSeries()
-        if self.axisX():
-            self.removeAxis(self.axisX())
-        if self.axisY():
-            self.removeAxis(self.axisY())
+        self.reset()
 
         self.setMinimumWidth(max(len(novel.chapters), 15) * 35)
 
@@ -240,3 +244,23 @@ class ManuscriptLengthChart(BaseChart):
         self.addSeries(series)
         series.attachAxis(axis_x)
         series.attachAxis(axis_y)
+
+
+class SceneStructureEmotionalArcChart(BaseChart):
+
+    def refresh(self, beats: List[SceneStructureItem]):
+        self.reset()
+
+        series = QSplineSeries()
+        arc_value: int = 0
+        series.append(0, 0)
+        for beat in beats:
+            if beat.emotion is not None:
+                arc_value = beat.emotion * 2
+            series.append(len(series), arc_value)
+
+        axis = QValueAxis()
+        axis.setRange(-8, 8)
+        self.addSeries(series)
+        self.setAxisY(axis, series)
+        axis.setVisible(False)

--- a/src/main/python/plotlyst/view/widget/input.py
+++ b/src/main/python/plotlyst/view/widget/input.py
@@ -45,7 +45,7 @@ from src.main.python.plotlyst.model.characters_model import CharactersTableModel
 from src.main.python.plotlyst.model.common import proxy
 from src.main.python.plotlyst.service.grammar import language_tool_proxy, dictionary
 from src.main.python.plotlyst.service.persistence import RepositoryPersistenceManager
-from src.main.python.plotlyst.view.common import OpacityEventFilter, action, autoresize_col, pointy
+from src.main.python.plotlyst.view.common import OpacityEventFilter, action, pointy, autoresize_col
 from src.main.python.plotlyst.view.icons import IconRegistry
 from src.main.python.plotlyst.view.widget._toggle import AnimatedToggle
 from src.main.python.plotlyst.view.widget.lang import GrammarPopupMenu
@@ -704,13 +704,22 @@ class MenuWithDescription(QMenu):
         self._model = self.Model()
 
         self._tblActions.verticalHeader().setMaximumSectionSize(20)
-        self._tblActions.setModel(self._model)
+        self._tblActions.setWordWrap(False)
+        self._tblActions.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self._tblActions.setShowGrid(False)
+        self._tblActions.setModel(self._model)
         self._tblActions.verticalHeader().setVisible(False)
         self._tblActions.horizontalHeader().setVisible(False)
         self._tblActions.horizontalHeader().setStretchLastSection(True)
-        self._tblActions.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Expanding)
         self._tblActions.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self._tblActions.setAlternatingRowColors(True)
+        self._tblActions.setStyleSheet('''
+            QTableView::item:hover:!selected {
+                background-color: #D8D5D5;
+                border: 0px;
+            }
+        ''')
+
         autoresize_col(self._tblActions, 0)
         pointy(self._tblActions)
         self._tblActions.clicked.connect(self._clicked)
@@ -719,6 +728,7 @@ class MenuWithDescription(QMenu):
         self._action.setDefaultWidget(self._tblActions)
         super().addAction(self._action)
 
+        self._model.freeze()
         self.aboutToShow.connect(lambda: self._model.unfreeze())
         self.aboutToHide.connect(lambda: self._model.freeze())
 
@@ -726,6 +736,8 @@ class MenuWithDescription(QMenu):
     def addAction(self, action: QAction, description: str = ''):
         self._model.addAction(action, description)
         self._tblActions.setMinimumHeight(self._model.rowCount() * 20 + 20)
+        minsize = max(len(description) * 10, self._tblActions.minimumWidth())
+        self._tblActions.setMinimumWidth(minsize)
 
     def _clicked(self, index: QModelIndex):
         action: QAction = self._model.action(index)
@@ -737,7 +749,7 @@ class MenuWithDescription(QMenu):
         def __init__(self, parent=None):
             super().__init__(parent)
             self._actions: List[Tuple[QAction, str]] = []
-            self._frozen: bool = True
+            self._frozen: bool = False
 
         @overrides
         def columnCount(self, parent: QModelIndex = ...) -> int:

--- a/src/main/python/plotlyst/view/widget/scenes.py
+++ b/src/main/python/plotlyst/view/widget/scenes.py
@@ -591,7 +591,7 @@ class SceneStructureWidget(QWidget, Ui_SceneStructureWidget):
         self.novel: Optional[Novel] = None
         self.scene: Optional[Scene] = None
 
-        self.btnInventory.setIcon(IconRegistry.from_name('mdi.file-tree-outline'))
+        self.wdgInventory.setHidden(True)
         decr_font(self.lblBeatsInventory)
         underline(self.lblBeatsInventory)
 
@@ -639,7 +639,7 @@ class SceneStructureWidget(QWidget, Ui_SceneStructureWidget):
         self.btnScene.clicked.connect(partial(self._typeClicked, SceneType.ACTION))
         self.btnSequel.clicked.connect(partial(self._typeClicked, SceneType.REACTION))
 
-        self.wdgAgendaCharacter.setDefaultText('Agenda character')
+        self.wdgAgendaCharacter.setDefaultText('Select character')
         self.wdgAgendaCharacter.characterSelected.connect(self._agendaCharacterSelected)
         self.unsetCharacterSlot = None
 
@@ -654,7 +654,6 @@ class SceneStructureWidget(QWidget, Ui_SceneStructureWidget):
         self._toggleCharacterStatus()
 
         self.reset()
-        self.btnInventory.setChecked(False)
 
         self._checkSceneType()
 
@@ -833,7 +832,6 @@ class SceneStructureWidget(QWidget, Ui_SceneStructureWidget):
             self.btnScene.setVisible(True)
             self.btnSequel.setChecked(False)
             self.btnSequel.setVisible(True)
-            self.btnInventory.setChecked(True)
 
     def _setEmotionColorChange(self):
         color_start = self.btnEmotionStart.color()
@@ -926,7 +924,6 @@ class SceneStructureWidget(QWidget, Ui_SceneStructureWidget):
                                               placeholder='Describe the middle part of this scene')
             bottom = SceneStructureItemWidget(self.novel, SceneStructureItem(SceneStructureItemType.BEAT),
                                               placeholder='Describe the ending of this scene')
-            self.btnInventory.setChecked(True)
             if self.btnScene.isHidden():
                 qtanim.fade_in(self.btnScene)
             if self.btnSequel.isHidden():

--- a/src/main/python/plotlyst/view/widget/scenes.py
+++ b/src/main/python/plotlyst/view/widget/scenes.py
@@ -30,7 +30,7 @@ from PyQt5.QtGui import QDragEnterEvent, QDragLeaveEvent, \
     QResizeEvent, QCursor, QColor, QDragMoveEvent, QDropEvent, QMouseEvent
 from PyQt5.QtGui import QPaintEvent, QPainter, QPen, QPainterPath
 from PyQt5.QtWidgets import QSizePolicy, QWidget, QFrame, QToolButton, QHBoxLayout, QSplitter, \
-    QPushButton, QHeaderView, QTreeView, QMenu, QWidgetAction, QTextEdit
+    QPushButton, QHeaderView, QTreeView, QMenu, QWidgetAction, QTextEdit, QLabel
 from overrides import overrides
 from qtanim import fade_out
 from qthandy import busy, margins, vspacer
@@ -58,6 +58,7 @@ from src.main.python.plotlyst.view.generated.scene_ouctome_selector_ui import Ui
 from src.main.python.plotlyst.view.generated.scene_structure_editor_widget_ui import Ui_SceneStructureWidget
 from src.main.python.plotlyst.view.generated.scenes_view_preferences_widget_ui import Ui_ScenesViewPreferences
 from src.main.python.plotlyst.view.icons import IconRegistry
+from src.main.python.plotlyst.view.layout import group
 from src.main.python.plotlyst.view.widget.button import WordWrappedPushButton, SecondaryActionToolButton
 from src.main.python.plotlyst.view.widget.characters import CharacterConflictSelector, CharacterGoalSelector
 from src.main.python.plotlyst.view.widget.input import RotatedButtonOrientation, RotatedButton
@@ -301,7 +302,7 @@ class SceneTagSelector(QWidget):
         flow(self.wdgTags)
         self.setStyleSheet('#wdgTags {background-color: white;}')
 
-        self.layout().addWidget(self.btnSelect, alignment=Qt.AlignTop)
+        self.layout().addWidget(group(self.btnSelect, QLabel('Tags:'), margin=0), alignment=Qt.AlignTop)
         self.layout().addWidget(self.wdgTags)
 
     def setScene(self, scene: Scene):

--- a/src/main/python/plotlyst/view/widget/scenes.py
+++ b/src/main/python/plotlyst/view/widget/scenes.py
@@ -439,7 +439,7 @@ class SceneStructureItemWidget(QWidget, Ui_SceneBeatItemWidget):
 class SceneGoalItemWidget(SceneStructureItemWidget):
     def __init__(self, novel: Novel, scene_structure_item: SceneStructureItem, parent=None):
         super(SceneGoalItemWidget, self).__init__(novel, scene_structure_item,
-                                                  placeholder='Goal of the character is clearly stated to the reader',
+                                                  placeholder='The character takes an action to achieve their goal',
                                                   parent=parent)
         self.btnIcon.setIcon(IconRegistry.goal_icon())
 
@@ -482,7 +482,7 @@ class DilemmaSceneItemWidget(SceneStructureItemWidget):
 class DecisionSceneItemWidget(SceneStructureItemWidget):
     def __init__(self, novel: Novel, scene_structure_item: SceneStructureItem, parent=None):
         super().__init__(novel, scene_structure_item,
-                         placeholder='The character comes up with a new goal and might act right away',
+                         placeholder='The character comes up with a new plan and might act right away',
                          parent=parent)
         self.btnIcon.setIcon(IconRegistry.decision_icon())
 

--- a/ui/scene_beat_item_widget.ui
+++ b/ui/scene_beat_item_widget.ui
@@ -6,45 +6,53 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>370</width>
-    <height>138</height>
+    <width>200</width>
+    <height>150</height>
    </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>160</width>
+    <height>150</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>200</width>
+    <height>150</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">
-    <number>3</number>
+    <number>0</number>
    </property>
    <property name="leftMargin">
-    <number>2</number>
+    <number>0</number>
    </property>
    <property name="topMargin">
-    <number>2</number>
+    <number>0</number>
    </property>
    <property name="rightMargin">
-    <number>2</number>
+    <number>0</number>
    </property>
    <property name="bottomMargin">
-    <number>2</number>
+    <number>0</number>
    </property>
    <item>
-    <layout class="QHBoxLayout" name="layoutTop">
-     <property name="spacing">
-      <number>2</number>
+    <spacer name="horizontalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
-     <item>
-      <widget class="QToolButton" name="btnPlaceholder">
-       <property name="styleSheet">
-        <string notr="true">border: 0px;</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-    </layout>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>197</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
    <item>
     <layout class="QHBoxLayout" name="layoutMiddle">
@@ -61,7 +69,7 @@
          <number>0</number>
         </property>
         <property name="topMargin">
-         <number>4</number>
+         <number>0</number>
         </property>
         <property name="rightMargin">
          <number>0</number>
@@ -69,55 +77,55 @@
         <property name="bottomMargin">
          <number>0</number>
         </property>
-        <item alignment="Qt::AlignTop">
-         <widget class="QToolButton" name="btnIcon">
+        <item>
+         <widget class="QTextEdit" name="text">
           <property name="styleSheet">
-           <string notr="true">border: 0px;</string>
+           <string notr="true"/>
           </property>
-          <property name="text">
-           <string/>
+          <property name="verticalScrollBarPolicy">
+           <enum>Qt::ScrollBarAlwaysOff</enum>
+          </property>
+          <property name="horizontalScrollBarPolicy">
+           <enum>Qt::ScrollBarAlwaysOff</enum>
           </property>
          </widget>
         </item>
+        <item>
+         <layout class="QHBoxLayout" name="layoutTop">
+          <property name="spacing">
+           <number>2</number>
+          </property>
+          <item alignment="Qt::AlignRight">
+           <widget class="QToolButton" name="btnDelete">
+            <property name="cursor">
+             <cursorShape>PointingHandCursor</cursorShape>
+            </property>
+            <property name="toolTip">
+             <string>Remove beat</string>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">border: 0px;</string>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+            <property name="iconSize">
+             <size>
+              <width>14</width>
+              <height>14</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
        </layout>
-      </widget>
-     </item>
-     <item>
-      <widget class="AutoAdjustableTextEdit" name="text"/>
-     </item>
-     <item alignment="Qt::AlignTop">
-      <widget class="QToolButton" name="btnDelete">
-       <property name="cursor">
-        <cursorShape>PointingHandCursor</cursorShape>
-       </property>
-       <property name="toolTip">
-        <string>Remove beat</string>
-       </property>
-       <property name="styleSheet">
-        <string notr="true">border: 0px;</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="iconSize">
-        <size>
-         <width>14</width>
-         <height>14</height>
-        </size>
-       </property>
       </widget>
      </item>
     </layout>
    </item>
   </layout>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>AutoAdjustableTextEdit</class>
-   <extends>QTextEdit</extends>
-   <header>src.main.python.plotlyst.view.widget.input</header>
-  </customwidget>
- </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/ui/scene_beat_item_widget.ui
+++ b/ui/scene_beat_item_widget.ui
@@ -6,20 +6,26 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>200</width>
-    <height>150</height>
+    <width>205</width>
+    <height>200</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="minimumSize">
    <size>
-    <width>160</width>
-    <height>150</height>
+    <width>180</width>
+    <height>200</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>200</width>
-    <height>150</height>
+    <width>233</width>
+    <height>200</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -55,77 +61,255 @@
     </spacer>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="layoutMiddle">
-     <property name="spacing">
-      <number>2</number>
-     </property>
-     <item>
-      <widget class="QWidget" name="widget" native="true">
-       <layout class="QVBoxLayout" name="verticalLayout_2">
+    <widget class="QWidget" name="widget" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QTextEdit" name="text">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>100</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>100</height>
+         </size>
+        </property>
+        <property name="styleSheet">
+         <string notr="true"/>
+        </property>
+        <property name="verticalScrollBarPolicy">
+         <enum>Qt::ScrollBarAlwaysOff</enum>
+        </property>
+        <property name="horizontalScrollBarPolicy">
+         <enum>Qt::ScrollBarAlwaysOff</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="wdgEmotions" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <property name="spacing">
+          <number>1</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item alignment="Qt::AlignLeft">
+          <widget class="SecondaryActionToolButton" name="btnEmotionN3">
+           <property name="iconSize">
+            <size>
+             <width>20</width>
+             <height>20</height>
+            </size>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="iconName" stdset="0">
+            <string>ri.emotion-unhappy-line</string>
+           </property>
+           <property name="checkedColor" stdset="0">
+            <string>#ef0000</string>
+           </property>
+           <property name="emotion" stdset="0">
+            <number>-3</number>
+           </property>
+          </widget>
+         </item>
+         <item alignment="Qt::AlignLeft">
+          <widget class="SecondaryActionToolButton" name="btnEmotionN2">
+           <property name="iconSize">
+            <size>
+             <width>20</width>
+             <height>20</height>
+            </size>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="iconName" stdset="0">
+            <string>mdi6.emoticon-sad-outline</string>
+           </property>
+           <property name="checkedColor" stdset="0">
+            <string>#ff8e2b</string>
+           </property>
+           <property name="emotion" stdset="0">
+            <number>-2</number>
+           </property>
+          </widget>
+         </item>
+         <item alignment="Qt::AlignLeft">
+          <widget class="SecondaryActionToolButton" name="btnEmotionN1">
+           <property name="iconSize">
+            <size>
+             <width>20</width>
+             <height>20</height>
+            </size>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="iconName" stdset="0">
+            <string>mdi.emoticon-confused-outline</string>
+           </property>
+           <property name="emotion" stdset="0">
+            <number>-1</number>
+           </property>
+          </widget>
+         </item>
+         <item alignment="Qt::AlignLeft">
+          <widget class="SecondaryActionToolButton" name="btnEmotionNeutral">
+           <property name="iconSize">
+            <size>
+             <width>20</width>
+             <height>20</height>
+            </size>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="iconName" stdset="0">
+            <string>mdi.emoticon-neutral-outline</string>
+           </property>
+           <property name="emotion" stdset="0">
+            <number>0</number>
+           </property>
+          </widget>
+         </item>
+         <item alignment="Qt::AlignLeft">
+          <widget class="SecondaryActionToolButton" name="btnEmotionP1">
+           <property name="iconSize">
+            <size>
+             <width>20</width>
+             <height>20</height>
+            </size>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="iconName" stdset="0">
+            <string>mdi6.emoticon-happy-outline</string>
+           </property>
+           <property name="emotion" stdset="0">
+            <number>1</number>
+           </property>
+          </widget>
+         </item>
+         <item alignment="Qt::AlignLeft">
+          <widget class="SecondaryActionToolButton" name="btnEmotionP2">
+           <property name="iconSize">
+            <size>
+             <width>20</width>
+             <height>20</height>
+            </size>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="iconName" stdset="0">
+            <string>ri.emotion-happy-line</string>
+           </property>
+           <property name="checkedColor" stdset="0">
+            <string>#93e5ab</string>
+           </property>
+           <property name="emotion" stdset="0">
+            <number>2</number>
+           </property>
+          </widget>
+         </item>
+         <item alignment="Qt::AlignLeft">
+          <widget class="SecondaryActionToolButton" name="btnEmotionP3">
+           <property name="iconSize">
+            <size>
+             <width>20</width>
+             <height>20</height>
+            </size>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="iconName" stdset="0">
+            <string>mdi6.emoticon-excited-outline</string>
+           </property>
+           <property name="checkedColor" stdset="0">
+            <string>#00ca94</string>
+           </property>
+           <property name="emotion" stdset="0">
+            <number>3</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="layoutTop">
         <property name="spacing">
-         <number>0</number>
+         <number>2</number>
         </property>
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="QTextEdit" name="text">
+        <item alignment="Qt::AlignRight">
+         <widget class="QToolButton" name="btnDelete">
+          <property name="cursor">
+           <cursorShape>PointingHandCursor</cursorShape>
+          </property>
+          <property name="toolTip">
+           <string>Remove beat</string>
+          </property>
           <property name="styleSheet">
-           <string notr="true"/>
+           <string notr="true">border: 0px;</string>
           </property>
-          <property name="verticalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
+          <property name="text">
+           <string/>
           </property>
-          <property name="horizontalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOff</enum>
+          <property name="iconSize">
+           <size>
+            <width>14</width>
+            <height>14</height>
+           </size>
           </property>
          </widget>
         </item>
-        <item>
-         <layout class="QHBoxLayout" name="layoutTop">
-          <property name="spacing">
-           <number>2</number>
-          </property>
-          <item alignment="Qt::AlignRight">
-           <widget class="QToolButton" name="btnDelete">
-            <property name="cursor">
-             <cursorShape>PointingHandCursor</cursorShape>
-            </property>
-            <property name="toolTip">
-             <string>Remove beat</string>
-            </property>
-            <property name="styleSheet">
-             <string notr="true">border: 0px;</string>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-            <property name="iconSize">
-             <size>
-              <width>14</width>
-              <height>14</height>
-             </size>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
        </layout>
-      </widget>
-     </item>
-    </layout>
+      </item>
+     </layout>
+    </widget>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>SecondaryActionToolButton</class>
+   <extends>QToolButton</extends>
+   <header>src.main.python.plotlyst.view.widget.button</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/ui/scene_editor.ui
+++ b/ui/scene_editor.ui
@@ -258,7 +258,7 @@
                </size>
               </property>
               <property name="placeholderText">
-               <string>Title</string>
+               <string>Scene title</string>
               </property>
              </widget>
             </item>

--- a/ui/scene_structure_editor_widget.ui
+++ b/ui/scene_structure_editor_widget.ui
@@ -49,347 +49,9 @@
         <number>2</number>
        </property>
        <item>
-        <layout class="QVBoxLayout" name="verticalLayout_11">
-         <property name="bottomMargin">
-          <number>5</number>
-         </property>
-         <item>
-          <widget class="QFrame" name="wdgInventory">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>16777215</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="styleSheet">
-            <string notr="true">#wdgInventory {
-	background-color: rgb(255, 255, 255);
-    border-radius: 6px;
-    border: 1 px solid black;
-}
-
-QToolButton {
-	background-color: rgb(255, 255, 255);
-    border-radius: 6px;
-    border: 1 px solid black;
-	icon-size: 17px;
-	font: 11px;
-}
-                                </string>
-           </property>
-           <property name="frameShape">
-            <enum>QFrame::Box</enum>
-           </property>
-           <property name="frameShadow">
-            <enum>QFrame::Raised</enum>
-           </property>
-           <layout class="QGridLayout" name="gridLayout_3">
-            <property name="leftMargin">
-             <number>0</number>
-            </property>
-            <property name="topMargin">
-             <number>0</number>
-            </property>
-            <property name="rightMargin">
-             <number>0</number>
-            </property>
-            <property name="bottomMargin">
-             <number>0</number>
-            </property>
-            <property name="spacing">
-             <number>2</number>
-            </property>
-            <item row="3" column="1" alignment="Qt::AlignHCenter">
-             <widget class="QToolButton" name="btnIncitingIncident">
-              <property name="cursor">
-               <cursorShape>OpenHandCursor</cursorShape>
-              </property>
-              <property name="text">
-               <string>Inciting
-incident</string>
-              </property>
-              <property name="iconSize">
-               <size>
-                <width>24</width>
-                <height>24</height>
-               </size>
-              </property>
-              <property name="toolButtonStyle">
-               <enum>Qt::ToolButtonTextUnderIcon</enum>
-              </property>
-             </widget>
-            </item>
-            <item row="5" column="0" alignment="Qt::AlignHCenter">
-             <widget class="QToolButton" name="btnExposition">
-              <property name="cursor">
-               <cursorShape>OpenHandCursor</cursorShape>
-              </property>
-              <property name="text">
-               <string>Image</string>
-              </property>
-              <property name="iconSize">
-               <size>
-                <width>24</width>
-                <height>24</height>
-               </size>
-              </property>
-              <property name="toolButtonStyle">
-               <enum>Qt::ToolButtonTextUnderIcon</enum>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="2" alignment="Qt::AlignHCenter">
-             <widget class="QToolButton" name="btnDecision">
-              <property name="cursor">
-               <cursorShape>OpenHandCursor</cursorShape>
-              </property>
-              <property name="text">
-               <string>Decision</string>
-              </property>
-              <property name="iconSize">
-               <size>
-                <width>24</width>
-                <height>24</height>
-               </size>
-              </property>
-              <property name="toolButtonStyle">
-               <enum>Qt::ToolButtonTextUnderIcon</enum>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="2" alignment="Qt::AlignHCenter">
-             <widget class="QToolButton" name="btnRisingAction">
-              <property name="cursor">
-               <cursorShape>OpenHandCursor</cursorShape>
-              </property>
-              <property name="text">
-               <string>Rising
-action</string>
-              </property>
-              <property name="iconSize">
-               <size>
-                <width>24</width>
-                <height>24</height>
-               </size>
-              </property>
-              <property name="toolButtonStyle">
-               <enum>Qt::ToolButtonTextUnderIcon</enum>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0" alignment="Qt::AlignHCenter">
-             <widget class="QToolButton" name="btnReaction">
-              <property name="cursor">
-               <cursorShape>OpenHandCursor</cursorShape>
-              </property>
-              <property name="text">
-               <string>Reaction</string>
-              </property>
-              <property name="iconSize">
-               <size>
-                <width>24</width>
-                <height>24</height>
-               </size>
-              </property>
-              <property name="toolButtonStyle">
-               <enum>Qt::ToolButtonTextUnderIcon</enum>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1" alignment="Qt::AlignHCenter">
-             <widget class="QToolButton" name="btnConflict">
-              <property name="cursor">
-               <cursorShape>OpenHandCursor</cursorShape>
-              </property>
-              <property name="text">
-               <string>Conflict</string>
-              </property>
-              <property name="iconSize">
-               <size>
-                <width>24</width>
-                <height>24</height>
-               </size>
-              </property>
-              <property name="toolButtonStyle">
-               <enum>Qt::ToolButtonTextUnderIcon</enum>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="2" alignment="Qt::AlignHCenter">
-             <widget class="QToolButton" name="btnOutcome">
-              <property name="cursor">
-               <cursorShape>OpenHandCursor</cursorShape>
-              </property>
-              <property name="text">
-               <string>Outcome</string>
-              </property>
-              <property name="iconSize">
-               <size>
-                <width>24</width>
-                <height>24</height>
-               </size>
-              </property>
-              <property name="toolButtonStyle">
-               <enum>Qt::ToolButtonTextUnderIcon</enum>
-              </property>
-             </widget>
-            </item>
-            <item row="6" column="0">
-             <spacer name="verticalSpacer_3">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="1" column="0" alignment="Qt::AlignHCenter">
-             <widget class="QToolButton" name="btnGoal">
-              <property name="cursor">
-               <cursorShape>OpenHandCursor</cursorShape>
-              </property>
-              <property name="text">
-               <string>Goal</string>
-              </property>
-              <property name="iconSize">
-               <size>
-                <width>24</width>
-                <height>24</height>
-               </size>
-              </property>
-              <property name="toolButtonStyle">
-               <enum>Qt::ToolButtonTextUnderIcon</enum>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1" alignment="Qt::AlignHCenter">
-             <widget class="QToolButton" name="btnDilemma">
-              <property name="cursor">
-               <cursorShape>OpenHandCursor</cursorShape>
-              </property>
-              <property name="text">
-               <string>Dilemma</string>
-              </property>
-              <property name="iconSize">
-               <size>
-                <width>24</width>
-                <height>24</height>
-               </size>
-              </property>
-              <property name="toolButtonStyle">
-               <enum>Qt::ToolButtonTextUnderIcon</enum>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="0" alignment="Qt::AlignHCenter">
-             <widget class="QToolButton" name="btnHook">
-              <property name="cursor">
-               <cursorShape>OpenHandCursor</cursorShape>
-              </property>
-              <property name="text">
-               <string>Hook</string>
-              </property>
-              <property name="iconSize">
-               <size>
-                <width>24</width>
-                <height>24</height>
-               </size>
-              </property>
-              <property name="toolButtonStyle">
-               <enum>Qt::ToolButtonTextUnderIcon</enum>
-              </property>
-             </widget>
-            </item>
-            <item row="5" column="1" alignment="Qt::AlignHCenter">
-             <widget class="QToolButton" name="btnBeat">
-              <property name="cursor">
-               <cursorShape>OpenHandCursor</cursorShape>
-              </property>
-              <property name="text">
-               <string>Beat</string>
-              </property>
-              <property name="iconSize">
-               <size>
-                <width>24</width>
-                <height>24</height>
-               </size>
-              </property>
-              <property name="toolButtonStyle">
-               <enum>Qt::ToolButtonTextUnderIcon</enum>
-              </property>
-             </widget>
-            </item>
-            <item row="4" column="0" alignment="Qt::AlignHCenter">
-             <widget class="QToolButton" name="btnTickingClock">
-              <property name="cursor">
-               <cursorShape>OpenHandCursor</cursorShape>
-              </property>
-              <property name="text">
-               <string>Ticking 
-Clock</string>
-              </property>
-              <property name="iconSize">
-               <size>
-                <width>24</width>
-                <height>24</height>
-               </size>
-              </property>
-              <property name="toolButtonStyle">
-               <enum>Qt::ToolButtonTextUnderIcon</enum>
-              </property>
-             </widget>
-            </item>
-            <item row="4" column="1" alignment="Qt::AlignHCenter">
-             <widget class="QToolButton" name="btnCrisis">
-              <property name="cursor">
-               <cursorShape>OpenHandCursor</cursorShape>
-              </property>
-              <property name="text">
-               <string>Crisis</string>
-              </property>
-              <property name="iconSize">
-               <size>
-                <width>24</width>
-                <height>24</height>
-               </size>
-              </property>
-              <property name="toolButtonStyle">
-               <enum>Qt::ToolButtonTextUnderIcon</enum>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0" colspan="3">
-             <widget class="QLabel" name="lblBeatsInventory">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Scene beats inventory</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
         <layout class="QVBoxLayout" name="verticalLayout_12">
          <property name="spacing">
-          <number>3</number>
+          <number>1</number>
          </property>
          <item>
           <layout class="QHBoxLayout" name="horizontalLayout_13">
@@ -432,7 +94,7 @@ Clock</string>
          <item>
           <layout class="QHBoxLayout" name="horizontalLayout_2">
            <property name="leftMargin">
-            <number>20</number>
+            <number>2</number>
            </property>
            <item>
             <widget class="QLabel" name="label">
@@ -475,69 +137,154 @@ Clock</string>
           </layout>
          </item>
          <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_11">
+          <spacer name="horizontalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>10</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_3">
            <property name="spacing">
-            <number>3</number>
+            <number>0</number>
            </property>
            <property name="leftMargin">
-            <number>10</number>
+            <number>2</number>
            </property>
+           <item alignment="Qt::AlignBottom">
+            <widget class="IconText" name="icontext">
+             <property name="font">
+              <font>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>Beginning</string>
+             </property>
+             <property name="iconName" stdset="0">
+              <string>mdi.ray-start</string>
+             </property>
+            </widget>
+           </item>
            <item>
-            <layout class="QVBoxLayout" name="verticalLayout_13">
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="font">
+              <font>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>End</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="Icon" name="icon">
+             <property name="iconName" stdset="0">
+              <string>mdi.ray-end</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="QScrollArea" name="scrollArea">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="frameShape">
+            <enum>QFrame::NoFrame</enum>
+           </property>
+           <property name="lineWidth">
+            <number>0</number>
+           </property>
+           <property name="verticalScrollBarPolicy">
+            <enum>Qt::ScrollBarAlwaysOff</enum>
+           </property>
+           <property name="widgetResizable">
+            <bool>true</bool>
+           </property>
+           <widget class="QWidget" name="scrollAreaWidgetContents">
+            <property name="geometry">
+             <rect>
+              <x>0</x>
+              <y>0</y>
+              <width>765</width>
+              <height>213</height>
+             </rect>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_2">
              <property name="spacing">
               <number>0</number>
              </property>
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
              <item>
-              <widget class="CharacterEmotionButton" name="btnEmotionStart">
-               <property name="text">
-                <string/>
-               </property>
-              </widget>
-             </item>
-             <item alignment="Qt::AlignHCenter">
-              <widget class="RotatedButton" name="btnEmotionRangeDisplay">
+              <widget class="QWidget" name="wdgTimelineParent" native="true">
                <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+                <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
                  <horstretch>0</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
                </property>
-               <property name="maximumSize">
+               <property name="minimumSize">
                 <size>
-                 <width>25</width>
-                 <height>16777215</height>
+                 <width>0</width>
+                 <height>0</height>
                 </size>
                </property>
-               <property name="styleSheet">
-                <string notr="true">border: 0px;</string>
-               </property>
-               <property name="text">
-                <string>Emotional change</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="CharacterEmotionButton" name="btnEmotionEnd">
-               <property name="text">
-                <string/>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-           <item>
-            <layout class="QVBoxLayout" name="verticalLayout_14">
-             <property name="spacing">
-              <number>1</number>
-             </property>
-             <item>
-              <widget class="QWidget" name="wdgBeginningLabel_2" native="true">
-               <layout class="QHBoxLayout" name="horizontalLayout_14">
+               <layout class="QVBoxLayout" name="verticalLayout">
                 <property name="spacing">
-                 <number>2</number>
+                 <number>0</number>
                 </property>
                 <property name="leftMargin">
-                 <number>0</number>
+                 <number>2</number>
                 </property>
                 <property name="topMargin">
                  <number>0</number>
@@ -548,332 +295,12 @@ Clock</string>
                 <property name="bottomMargin">
                  <number>0</number>
                 </property>
-                <item>
-                 <widget class="QToolButton" name="btnBeginningIcon">
-                  <property name="maximumSize">
-                   <size>
-                    <width>16777215</width>
-                    <height>28</height>
-                   </size>
-                  </property>
-                  <property name="styleSheet">
-                   <string notr="true">border: 0px;</string>
-                  </property>
-                  <property name="text">
-                   <string/>
-                  </property>
-                  <property name="iconSize">
-                   <size>
-                    <width>32</width>
-                    <height>32</height>
-                   </size>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLabel" name="label_5">
-                  <property name="maximumSize">
-                   <size>
-                    <width>16777215</width>
-                    <height>28</height>
-                   </size>
-                  </property>
-                  <property name="font">
-                   <font>
-                    <weight>75</weight>
-                    <bold>true</bold>
-                    <underline>true</underline>
-                   </font>
-                  </property>
-                  <property name="text">
-                   <string>Beginning</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <spacer name="horizontalSpacer">
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>40</width>
-                    <height>5</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
                </layout>
               </widget>
              </item>
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_15">
-               <item>
-                <spacer name="horizontalSpacer_23">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeType">
-                  <enum>QSizePolicy::Preferred</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item>
-                <widget class="QWidget" name="wdgBeginning" native="true">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <layout class="QVBoxLayout" name="verticalLayout_15">
-                  <property name="spacing">
-                   <number>0</number>
-                  </property>
-                  <property name="leftMargin">
-                   <number>2</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>2</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>2</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>2</number>
-                  </property>
-                 </layout>
-                </widget>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_17">
-               <property name="spacing">
-                <number>2</number>
-               </property>
-               <item>
-                <widget class="QToolButton" name="btnMiddleIcon">
-                 <property name="maximumSize">
-                  <size>
-                   <width>16777215</width>
-                   <height>28</height>
-                  </size>
-                 </property>
-                 <property name="styleSheet">
-                  <string notr="true">border: 0px;</string>
-                 </property>
-                 <property name="text">
-                  <string/>
-                 </property>
-                 <property name="iconSize">
-                  <size>
-                   <width>32</width>
-                   <height>32</height>
-                  </size>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLabel" name="label_6">
-                 <property name="maximumSize">
-                  <size>
-                   <width>16777215</width>
-                   <height>28</height>
-                  </size>
-                 </property>
-                 <property name="font">
-                  <font>
-                   <weight>75</weight>
-                   <bold>true</bold>
-                   <underline>true</underline>
-                  </font>
-                 </property>
-                 <property name="text">
-                  <string>Middle</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <spacer name="horizontalSpacer_6">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_18">
-               <item>
-                <spacer name="horizontalSpacer_24">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeType">
-                  <enum>QSizePolicy::Preferred</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item>
-                <widget class="QWidget" name="wdgMiddle" native="true">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <layout class="QVBoxLayout" name="verticalLayout_16">
-                  <property name="spacing">
-                   <number>0</number>
-                  </property>
-                  <property name="leftMargin">
-                   <number>2</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>2</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>2</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>2</number>
-                  </property>
-                 </layout>
-                </widget>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_19">
-               <property name="spacing">
-                <number>2</number>
-               </property>
-               <item>
-                <widget class="QToolButton" name="btnEndIcon">
-                 <property name="maximumSize">
-                  <size>
-                   <width>16777215</width>
-                   <height>28</height>
-                  </size>
-                 </property>
-                 <property name="styleSheet">
-                  <string notr="true">border: 0px;</string>
-                 </property>
-                 <property name="text">
-                  <string/>
-                 </property>
-                 <property name="iconSize">
-                  <size>
-                   <width>32</width>
-                   <height>32</height>
-                  </size>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLabel" name="label_7">
-                 <property name="maximumSize">
-                  <size>
-                   <width>16777215</width>
-                   <height>28</height>
-                  </size>
-                 </property>
-                 <property name="font">
-                  <font>
-                   <weight>75</weight>
-                   <bold>true</bold>
-                   <underline>true</underline>
-                  </font>
-                 </property>
-                 <property name="text">
-                  <string>End</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <spacer name="horizontalSpacer_7">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_20">
-               <item>
-                <spacer name="horizontalSpacer_25">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeType">
-                  <enum>QSizePolicy::Preferred</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item>
-                <widget class="QWidget" name="wdgEnd" native="true">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <layout class="QVBoxLayout" name="verticalLayout_17">
-                  <property name="spacing">
-                   <number>0</number>
-                  </property>
-                  <property name="leftMargin">
-                   <number>2</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>2</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>2</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>2</number>
-                  </property>
-                 </layout>
-                </widget>
-               </item>
-              </layout>
-             </item>
             </layout>
-           </item>
-          </layout>
+           </widget>
+          </widget>
          </item>
          <item>
           <spacer name="verticalSpacer_5">
@@ -898,14 +325,14 @@ Clock</string>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>RotatedButton</class>
-   <extends>QPushButton</extends>
-   <header>src.main.python.plotlyst.view.widget.input</header>
+   <class>Icon</class>
+   <extends>QToolButton</extends>
+   <header>src.main.python.plotlyst.view.widget.display</header>
   </customwidget>
   <customwidget>
-   <class>CharacterEmotionButton</class>
-   <extends>QToolButton</extends>
-   <header>src.main.python.plotlyst.view.widget.characters</header>
+   <class>IconText</class>
+   <extends>QPushButton</extends>
+   <header>src.main.python.plotlyst.view.widget.display</header>
   </customwidget>
   <customwidget>
    <class>CharacterLinkWidget</class>

--- a/ui/scene_structure_editor_widget.ui
+++ b/ui/scene_structure_editor_widget.ui
@@ -214,7 +214,7 @@
            </item>
           </layout>
          </item>
-         <item>
+         <item alignment="Qt::AlignTop">
           <widget class="QScrollArea" name="scrollArea">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -240,7 +240,7 @@
               <x>0</x>
               <y>0</y>
               <width>765</width>
-              <height>213</height>
+              <height>220</height>
              </rect>
             </property>
             <property name="sizePolicy">
@@ -276,7 +276,13 @@
                <property name="minimumSize">
                 <size>
                  <width>0</width>
-                 <height>0</height>
+                 <height>220</height>
+                </size>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>16777215</width>
+                 <height>220</height>
                 </size>
                </property>
                <layout class="QVBoxLayout" name="verticalLayout">
@@ -303,17 +309,20 @@
           </widget>
          </item>
          <item>
-          <spacer name="verticalSpacer_5">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
+          <widget class="ChartView" name="chartViewEmotionArc">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
            </property>
-           <property name="sizeHint" stdset="0">
+           <property name="minimumSize">
             <size>
-             <width>20</width>
-             <height>10</height>
+             <width>73</width>
+             <height>40</height>
             </size>
            </property>
-          </spacer>
+          </widget>
          </item>
         </layout>
        </item>
@@ -324,6 +333,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>ChartView</class>
+   <extends>QGraphicsView</extends>
+   <header>src.main.python.plotlyst.view.widget.display</header>
+  </customwidget>
   <customwidget>
    <class>Icon</class>
    <extends>QToolButton</extends>

--- a/ui/scene_structure_editor_widget.ui
+++ b/ui/scene_structure_editor_widget.ui
@@ -53,31 +53,6 @@
          <property name="bottomMargin">
           <number>5</number>
          </property>
-         <item alignment="Qt::AlignTop">
-          <widget class="QToolButton" name="btnInventory">
-           <property name="cursor">
-            <cursorShape>PointingHandCursor</cursorShape>
-           </property>
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Toggle scene beats inventory&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-           <property name="text">
-            <string/>
-           </property>
-           <property name="iconSize">
-            <size>
-             <width>20</width>
-             <height>20</height>
-            </size>
-           </property>
-           <property name="checkable">
-            <bool>true</bool>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
          <item>
           <widget class="QFrame" name="wdgInventory">
            <property name="sizePolicy">
@@ -418,7 +393,7 @@ Clock</string>
          </property>
          <item>
           <layout class="QHBoxLayout" name="horizontalLayout_13">
-           <item alignment="Qt::AlignRight">
+           <item>
             <widget class="QWidget" name="wdgTypes" native="true">
              <layout class="QHBoxLayout" name="horizontalLayout_10">
               <property name="spacing">
@@ -439,10 +414,65 @@ Clock</string>
              </layout>
             </widget>
            </item>
+           <item>
+            <spacer name="horizontalSpacer_2">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
           </layout>
          </item>
-         <item alignment="Qt::AlignLeft">
-          <widget class="CharacterLinkWidget" name="wdgAgendaCharacter" native="true"/>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_2">
+           <property name="leftMargin">
+            <number>20</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label">
+             <property name="font">
+              <font>
+               <underline>true</underline>
+              </font>
+             </property>
+             <property name="text">
+              <string>Agenda character:</string>
+             </property>
+            </widget>
+           </item>
+           <item alignment="Qt::AlignLeft">
+            <widget class="CharacterLinkWidget" name="wdgAgendaCharacter" native="true">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QWidget" name="wdgGoalConflictContainer" native="true">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </item>
          <item>
           <layout class="QHBoxLayout" name="horizontalLayout_11">
@@ -500,9 +530,6 @@ Clock</string>
              <property name="spacing">
               <number>1</number>
              </property>
-             <item>
-              <widget class="QWidget" name="wdgGoalConflictContainer" native="true"/>
-             </item>
              <item>
               <widget class="QWidget" name="wdgBeginningLabel_2" native="true">
                <layout class="QHBoxLayout" name="horizontalLayout_14">
@@ -888,22 +915,5 @@ Clock</string>
   </customwidget>
  </customwidgets>
  <resources/>
- <connections>
-  <connection>
-   <sender>btnInventory</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>wdgInventory</receiver>
-   <slot>setVisible(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>30</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>13</x>
-     <y>52</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>


### PR DESCRIPTION
- [x] scene type on the left
- [ ] add exposition scene type
- [x] icon for structure btn
- [x] agenda char label
- [x] goal and conflict in the same row with agenda character
- [x] vertical timeline
- [x] beat dots on line for addition
- [x] beat selector
- [x] beat widgets
- [x] restore
- [x] remove beat widget
- [x] associate emoji to beat
- [x] display scene emotional arc
- [x] tags label
- [x] Exposition beat
- [x] Beginning, middle, end parts
- [ ] Add turning point beat
- [x] smarter type changes and beat recreation
- [ ] reset agenda character on scene switch
- [ ] make on-stage characters clickable
- [x] change scene action type based on outcome