### PR TITLE
Start manuscript chapter view

### DIFF
--- a/src/main/python/plotlyst/core/domain.py
+++ b/src/main/python/plotlyst/core/domain.py
@@ -227,6 +227,9 @@ class Chapter:
     def sid(self) -> str:
         return str(self.id)
 
+    def title_index(self, novel: 'Novel') -> str:
+        return f'Chapter {novel.chapters.index(self) + 1}'
+
 
 @dataclass
 class CharacterArc:

--- a/src/main/python/plotlyst/view/common.py
+++ b/src/main/python/plotlyst/view/common.py
@@ -28,10 +28,10 @@ from PyQt5.QtCore import Qt, QRectF, QModelIndex, QRect, QPoint, QObject, QEvent
 from PyQt5.QtGui import QPixmap, QPainterPath, QPainter, QFont, QColor, QIcon, QDrag
 from PyQt5.QtWidgets import QWidget, QSizePolicy, QColorDialog, QAbstractItemView, \
     QMenu, QAction, QAbstractButton, \
-    QStackedWidget, QAbstractScrollArea, QLineEdit, QHeaderView
+    QStackedWidget, QAbstractScrollArea, QLineEdit, QHeaderView, QScrollArea, QFrame
 from fbs_runtime import platform
 from overrides import overrides
-from qthandy import opaque
+from qthandy import opaque, hbox
 
 from src.main.python.plotlyst.env import app_env
 
@@ -288,3 +288,20 @@ def autoresize_col(view: QAbstractItemView, col: int):
 
 def stretch_col(view: QAbstractItemView, col: int):
     view.horizontalHeader().setSectionResizeMode(col, QHeaderView.Stretch)
+
+
+def scrolled(parent: QWidget, frameless: bool = False) -> Tuple[QScrollArea, QWidget]:
+    scrollArea = QScrollArea(parent)
+    scrollArea.setFocusPolicy(Qt.NoFocus)
+    scrollArea.setWidgetResizable(True)
+
+    widget = QWidget(scrollArea)
+    scrollArea.setWidget(widget)
+    if not parent.layout():
+        hbox(parent, 0, 0)
+    parent.layout().addWidget(scrollArea)
+
+    if frameless:
+        scrollArea.setFrameStyle(QFrame.NoFrame)
+
+    return scrollArea, widget

--- a/src/main/python/plotlyst/view/manuscript_view.py
+++ b/src/main/python/plotlyst/view/manuscript_view.py
@@ -123,6 +123,7 @@ class ManuscriptView(AbstractNovelView):
 
         self.ui.wdgBottom.layout().addWidget(self.ui.lblWordCount, alignment=Qt.AlignCenter)
         self.ui.lblWordCount.setStyleSheet('color: black')
+        self.ui.lblWordCount.setVisible(True)
         self.ui.wdgEditor.layout().insertWidget(0, self.ui.textEdit)
         self.ui.wdgReadability.cbAdverbs.setChecked(False)
 

--- a/src/main/python/plotlyst/view/manuscript_view.py
+++ b/src/main/python/plotlyst/view/manuscript_view.py
@@ -143,8 +143,6 @@ class ManuscriptView(AbstractNovelView):
             self.ui.textEdit.setScene(node.scene)
 
             self.ui.textEdit.setMargins(30, 30, 30, 30)
-            # self.ui.textEdit.textEdit.setFormat(130, textIndent=20)
-            # self.ui.textEdit.textEdit.setFontPointSize(16)
             self._text_changed()
 
             if self.ui.cbSpellCheck.isChecked():

--- a/src/main/python/plotlyst/view/manuscript_view.py
+++ b/src/main/python/plotlyst/view/manuscript_view.py
@@ -35,7 +35,8 @@ from src.main.python.plotlyst.view.common import OpacityEventFilter
 from src.main.python.plotlyst.view.generated.manuscript_view_ui import Ui_ManuscriptView
 from src.main.python.plotlyst.view.icons import IconRegistry, avatars
 from src.main.python.plotlyst.view.widget.chart import ManuscriptLengthChart
-from src.main.python.plotlyst.view.widget.manuscript import ManuscriptContextMenuWidget, DistractionFreeManuscriptEditor
+from src.main.python.plotlyst.view.widget.manuscript import ManuscriptContextMenuWidget, \
+    DistractionFreeManuscriptEditor, ManuscriptTextEdit
 
 
 class ManuscriptView(AbstractNovelView):
@@ -170,7 +171,7 @@ class ManuscriptView(AbstractNovelView):
                 self.ui.btnSceneType.setHidden(True)
 
             if self.ui.btnAnalysis.isChecked():
-                self.ui.wdgReadability.checkTextDocument(self.ui.textEdit.textEdit.document())
+                self.ui.wdgReadability.checkTextDocuments(self.ui.textEdit.documents())
 
         elif isinstance(node, ChapterNode):
             self.ui.stackedWidget.setCurrentWidget(self.ui.pageEmpty)
@@ -179,10 +180,10 @@ class ManuscriptView(AbstractNovelView):
         wc = self.ui.textEdit.statistics().word_count
         self.ui.lblWordCount.setWordCount(wc)
         self._update_story_goal()
-        # self.ui.wdgReadability.setTextDocumentUpdated(self.ui.textEdit.textEdit.document())
+        self.ui.wdgReadability.setTextDocumentsUpdated(self.ui.textEdit.documents())
 
-    def _text_selection_changed(self):
-        fragment = self.ui.textEdit.textEdit.textCursor().selection()
+    def _text_selection_changed(self, editor: ManuscriptTextEdit):
+        fragment = editor.textCursor().selection()
         if fragment:
             self.ui.lblWordCount.calculateSecondaryWordCount(fragment.toPlainText())
         else:
@@ -220,7 +221,7 @@ class ManuscriptView(AbstractNovelView):
         if not checked:
             return
 
-        self.ui.wdgReadability.checkTextDocument(self.ui.textEdit.textEdit.document())
+        self.ui.wdgReadability.checkTextDocuments(self.ui.textEdit.documents())
 
     def _adverb_highlight_toggled(self, toggled: bool):
         if toggled:

--- a/src/main/python/plotlyst/view/widget/manuscript.py
+++ b/src/main/python/plotlyst/view/widget/manuscript.py
@@ -55,8 +55,6 @@ from src.main.python.plotlyst.view.widget.display import WordsDisplay
 from src.main.python.plotlyst.view.widget.input import TextEditBase, GrammarHighlighter, GrammarHighlightStyle
 
 
-# comment to trigger ci
-
 class TimerSetupWidget(QWidget, Ui_TimerSetupWidget):
     def __init__(self, parent=None):
         super(TimerSetupWidget, self).__init__(parent)
@@ -487,7 +485,7 @@ class ManuscriptTextEditor(QWidget):
         editor.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         editor.resizeToContent()
         editor.textChanged.connect(partial(self._textChanged, scene, editor))
-        editor.selectionChanged.connect(partial(self.selectionChanged.emit, editor))
+        editor.selectionChanged.connect(partial(self._selectionChanged, editor))
         self._editors.append(editor)
         self._scrollWidget.layout().addWidget(editor)
 
@@ -552,6 +550,14 @@ class ManuscriptTextEditor(QWidget):
         self.repo.update_doc(app_env.novel, scene.manuscript)
 
         self.textChanged.emit()
+
+    def _selectionChanged(self, editor: ManuscriptTextEdit):
+        for edt in self._editors:
+            cursor = edt.textCursor()
+            if edt != editor and cursor.hasSelection():
+                cursor.clearSelection()
+                edt.setTextCursor(cursor)
+        self.selectionChanged.emit(editor)
 
 
 class ReadabilityWidget(QWidget, Ui_ReadabilityWidget):

--- a/src/main/python/plotlyst/view/widget/manuscript.py
+++ b/src/main/python/plotlyst/view/widget/manuscript.py
@@ -473,7 +473,7 @@ class ManuscriptTextEditor(QWidget):
         clear_layout(self._scrollWidget.layout())
         self._editors.clear()
 
-    def _addScene(self, scene, topBorder: bool = False):
+    def _addScene(self, scene: Scene, topBorder: bool = False):
         if not scene.manuscript.loaded:
             json_client.load_document(app_env.novel, scene.manuscript)
 
@@ -482,6 +482,7 @@ class ManuscriptTextEditor(QWidget):
         editor.setFormat(130, textIndent=20)
         editor.setFontPointSize(16)
         editor.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        editor.verticalScrollBar().setEnabled(False)
         editor.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         editor.resizeToContent()
         editor.textChanged.connect(partial(self._textChanged, scene, editor))

--- a/src/main/python/plotlyst/view/widget/manuscript.py
+++ b/src/main/python/plotlyst/view/widget/manuscript.py
@@ -31,7 +31,7 @@ from PyQt5.QtMultimedia import QSoundEffect
 from PyQt5.QtWidgets import QWidget, QTextEdit, QApplication, QSizePolicy
 from nltk import WhitespaceTokenizer
 from overrides import overrides
-from qthandy import retain_when_hidden, opaque, btn_popup, transparent, clear_layout, vbox
+from qthandy import retain_when_hidden, opaque, btn_popup, clear_layout, vbox
 from textstat import textstat
 
 from src.main.python.plotlyst.common import RELAXED_WHITE_COLOR
@@ -414,7 +414,7 @@ class ManuscriptTextEdit(TextEditBase):
     def setNightModeEnabled(self, enabled: bool):
         self.clearHighlights()
         if enabled:
-            transparent(self)
+            self._transparent()
             self._nightModeHighlighter = NightModeHighlighter(self)
 
     def setSentenceHighlighterEnabled(self, enabled: bool):
@@ -427,10 +427,14 @@ class ManuscriptTextEdit(TextEditBase):
         if enabled:
             self._wordTagHighlighter = WordTagHighlighter(self)
 
+    def _transparent(self):
+        border = 2 if self._topBorder else 0
+        self.setStyleSheet(f'border-top: {border}px dashed {RELAXED_WHITE_COLOR}; background-color: rgba(0, 0, 0, 0);')
+
     def _setDefaultStyleSheet(self):
         border = 2 if self._topBorder else 0
         self.setStyleSheet(
-            f'QTextEdit {{border-top: {border}px dashed grey; background-color: {RELAXED_WHITE_COLOR};}}')
+            f'ManuscriptTextEdit {{border-top: {border}px dashed grey; background-color: {RELAXED_WHITE_COLOR};}}')
 
 
 class ManuscriptTextEditor(QWidget):
@@ -442,6 +446,7 @@ class ManuscriptTextEditor(QWidget):
         vbox(self, 0, 0)
         self._scrollArea, self._scrollWidget = scrolled(self, frameless=True)
         self._scrollArea.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+        self._scrollWidget.setStyleSheet('border: 0px; background-color: rgb(39, 39, 39);')
         vbox(self._scrollWidget, 0, 0)
 
         self._editors: List[ManuscriptTextEdit] = []
@@ -496,6 +501,9 @@ class ManuscriptTextEditor(QWidget):
     def statistics(self) -> TextStatistics:
         wc = sum([x.statistics().word_count for x in self._editors], 0)
         return TextStatistics(wc)
+
+    def setViewportMargins(self, left: int, top: int, right: int, bottom: int):
+        self._scrollArea.setViewportMargins(left, top, right, bottom)
 
     def setMargins(self, left: int, top: int, right: int, bottom: int):
         if not self._editors:
@@ -690,6 +698,7 @@ class DistractionFreeManuscriptEditor(QWidget, Ui_DistractionFreeManuscriptEdito
     def deactivate(self):
         self.editor.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
         self.editor.removeEventFilterFromEditors(self)
+        self.editor.setViewportMargins(0, 0, 0, 0)
         self.editor.setMargins(30, 30, 30, 30)
         self._toggle_manuscript_focus(False)
         self._toggle_manuscript_night_mode(False)
@@ -742,9 +751,9 @@ class DistractionFreeManuscriptEditor(QWidget, Ui_DistractionFreeManuscriptEdito
 
     def _toggle_typewriter_mode(self, toggled: bool):
         if toggled:
-            self.editor.setMargins(30, 30, 30, QApplication.desktop().height() // 2)
+            self.editor.setViewportMargins(0, 0, 0, QApplication.desktop().height() // 2)
         else:
-            self.editor.setMargins(30, 30, 30, 30)
+            self.editor.setViewportMargins(0, 0, 0, 0)
 
     def _autoHideBottomBar(self):
         if not self.wdgBottom.underMouse():

--- a/src/main/python/plotlyst/view/widget/manuscript.py
+++ b/src/main/python/plotlyst/view/widget/manuscript.py
@@ -55,6 +55,8 @@ from src.main.python.plotlyst.view.widget.display import WordsDisplay
 from src.main.python.plotlyst.view.widget.input import TextEditBase, GrammarHighlighter, GrammarHighlightStyle
 
 
+# comment to trigger ci
+
 class TimerSetupWidget(QWidget, Ui_TimerSetupWidget):
     def __init__(self, parent=None):
         super(TimerSetupWidget, self).__init__(parent)

--- a/src/main/python/plotlyst/view/widget/manuscript.py
+++ b/src/main/python/plotlyst/view/widget/manuscript.py
@@ -585,11 +585,14 @@ class ReadabilityWidget(QWidget, Ui_ReadabilityWidget):
         if not docs:
             return
 
-        doc = docs[0]
+        text = ''
+        cleaned_text = ''
+        for doc in docs:
+            _txt = doc.toPlainText()
+            cleaned_text += clean_text(_txt)
+            text += _txt
         spin(self.btnResult)
 
-        text = doc.toPlainText()
-        cleaned_text = clean_text(text)
         score = textstat.flesch_reading_ease(cleaned_text)
         self.btnResult.setToolTip(f'Flesch–Kincaid readability score: {score}')
 
@@ -612,11 +615,12 @@ class ReadabilityWidget(QWidget, Ui_ReadabilityWidget):
             self.lblResult.setText('<i style="color:#85182a">Very difficult to read</i>')
 
         sentences_count = 0
-        for i in range(doc.blockCount()):
-            block = doc.findBlockByNumber(i)
-            block_text = block.text()
-            if block_text:
-                sentences_count += sentence_count(block_text)
+        for doc in docs:
+            for i in range(doc.blockCount()):
+                block = doc.findBlockByNumber(i)
+                block_text = block.text()
+                if block_text:
+                    sentences_count += sentence_count(block_text)
 
         if not sentences_count:
             sentence_length = 0

--- a/src/main/python/plotlyst/view/widget/manuscript.py
+++ b/src/main/python/plotlyst/view/widget/manuscript.py
@@ -493,8 +493,8 @@ class ManuscriptTextEditor(QWidget):
         return [x.document() for x in self._editors]
 
     def statistics(self) -> TextStatistics:
-        if self._editors:
-            return self._editors[0].statistics()
+        wc = sum([x.statistics().word_count for x in self._editors], 0)
+        return TextStatistics(wc)
 
     def setMargins(self, left: int, top: int, right: int, bottom: int):
         if not self._editors:

--- a/src/main/python/plotlyst/view/widget/manuscript.py
+++ b/src/main/python/plotlyst/view/widget/manuscript.py
@@ -19,7 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 import datetime
 from functools import partial
-from typing import Optional
+from typing import Optional, List
 
 import nltk
 import qtanim
@@ -31,12 +31,12 @@ from PyQt5.QtMultimedia import QSoundEffect
 from PyQt5.QtWidgets import QWidget, QTextEdit, QApplication
 from nltk import WhitespaceTokenizer
 from overrides import overrides
-from qthandy import retain_when_hidden, opaque, btn_popup, transparent, clear_layout
+from qthandy import retain_when_hidden, opaque, btn_popup, transparent, clear_layout, vbox
 from qttextedit import EnhancedTextEdit
 from textstat import textstat
 
 from src.main.python.plotlyst.common import RELAXED_WHITE_COLOR
-from src.main.python.plotlyst.core.domain import Novel
+from src.main.python.plotlyst.core.domain import Novel, Document
 from src.main.python.plotlyst.core.sprint import TimerModel
 from src.main.python.plotlyst.core.text import wc, sentence_count, clean_text
 from src.main.python.plotlyst.env import app_env
@@ -416,6 +416,16 @@ class ManuscriptTextEditor(DocumentTextEditor):
         self.textEdit.setStyleSheet(f'QTextEdit {{border: 1px; background-color: {RELAXED_WHITE_COLOR};}}')
 
 
+class ManuscriptBatchEditor(QWidget):
+    def __init__(self, parent=None):
+        super(ManuscriptBatchEditor, self).__init__(parent)
+
+        vbox(self, 0, 0)
+
+    def setManuscripts(self, manuscripts: List[Document]):
+        pass
+
+
 class ReadabilityWidget(QWidget, Ui_ReadabilityWidget):
     def __init__(self, parent=None):
         super(ReadabilityWidget, self).__init__(parent)
@@ -519,9 +529,9 @@ class DistractionFreeManuscriptEditor(QWidget, Ui_DistractionFreeManuscriptEdito
             self.wdgSprint.setVisible(True)
         else:
             self.wdgSprint.setHidden(True)
-        self.wdgDistractionFreeEditor.layout().addWidget(editor)
-        editor.textEdit.setFocus()
-        editor.textEdit.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.wdgDistractionFreeEditor.layout().addWidget(self.editor)
+        self.editor.textEdit.setFocus()
+        self.editor.textEdit.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.wdgBottom.setVisible(True)
         self.sliderDocWidth.setMaximum(self.width() / 3)
         if self.sliderDocWidth.value() <= 2:

--- a/ui/manuscript_view.ui
+++ b/ui/manuscript_view.ui
@@ -209,7 +209,7 @@ background-color: rgb(39, 39, 39);
        <number>0</number>
       </property>
       <property name="currentIndex">
-       <number>1</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="pageText">
        <property name="styleSheet">


### PR DESCRIPTION
- [x] chapter title
- [x] replace ManuscriptTextEditor with QWidget delegate
- [x] multiple ManuscriptTextEdit
- [x] wc together
- [x] highlight together
- [x] edit -> save scene only
- [x] adjustable text
- [x] distfree mode
- [x] exclusive text selection
- [x] sort out current_scene
- [x] sort out current_doc
- [x] common QTextEdit signals in ManuscriptTextEditor
- [x] analysis on multiple docs
- [x] remove any `ui.textEdit.textEdit` usages
- [x] work for single doc: editing and saving
- [x] work for single doc: grammar
- [x] work for single doc: readability
- [x] work for single doc: dist free editing
- [x] work for single doc: dist free highlights