### PR TITLE
Associate stakes to scene-goals

### DIFF
--- a/src/main/python/plotlyst/core/domain.py
+++ b/src/main/python/plotlyst/core/domain.py
@@ -506,10 +506,20 @@ class ConflictReference:
     intensity: int = 1
 
 
+class Stake:
+    PHYSIOLOGICAL = 0
+    SAFETY = 1
+    BELONGING = 2
+    ESTEEM = 3
+    SELF_ACTUALIZATION = 4
+    SELF_TRANSCENDENCE = 5
+
+
 @dataclass
 class GoalReference:
     character_goal_id: uuid.UUID
     message: str = ''
+    stakes: Dict[int, int] = field(default_factory=dict, metadata=config(exclude=exclude_if_empty))
 
     def goal(self, character: Character) -> CharacterGoal:
         for goal_ in character.flatten_goals():

--- a/src/main/python/plotlyst/core/domain.py
+++ b/src/main/python/plotlyst/core/domain.py
@@ -511,6 +511,11 @@ class GoalReference:
     character_goal_id: uuid.UUID
     message: str = ''
 
+    def goal(self, character: Character) -> CharacterGoal:
+        for goal_ in character.flatten_goals():
+            if goal_.id == self.character_goal_id:
+                return goal_
+
 
 @dataclass
 class TagReference:

--- a/src/main/python/plotlyst/core/text.py
+++ b/src/main/python/plotlyst/core/text.py
@@ -115,3 +115,19 @@ def clean_text(text: str):
 def sentence_count(text: str) -> int:
     text = clean_text(text)
     return len(nltk.text.sent_tokenize(text))
+
+
+class HtmlString(str):
+    def __init__(self, text: str):
+        self.text = text
+
+    def bold(self) -> str:
+        self.text = f'<b>{self.text}</b>'
+        return self.text
+
+    def __str__(self):
+        return self.text
+
+
+def html(text: str) -> HtmlString:
+    return HtmlString(text)

--- a/src/main/python/plotlyst/model/report.py
+++ b/src/main/python/plotlyst/model/report.py
@@ -23,7 +23,7 @@ from PyQt5.QtCore import QModelIndex, Qt
 from anytree import Node
 from overrides import overrides
 
-from src.main.python.plotlyst.core.domain import VERY_UNHAPPY
+from src.main.python.plotlyst.core.domain import HAPPY
 from src.main.python.plotlyst.model.tree_model import TreeItemModel
 from src.main.python.plotlyst.view.icons import IconRegistry
 
@@ -33,6 +33,10 @@ class CharacterReportNode(Node):
 
 
 class CharacterArcReportNode(Node):
+    pass
+
+
+class StakesReportNode(Node):
     pass
 
 
@@ -49,6 +53,7 @@ class ReportsTreeModel(TreeItemModel):
         super(ReportsTreeModel, self).__init__(parent)
         char_node = CharacterReportNode('Characters', self.root)
         CharacterArcReportNode('Emotional Arc', char_node)
+        StakesReportNode('Stakes', self.root)
         ConflictReportNode('Conflicts', self.root)
         PlotReportNode('Plot', self.root)
 
@@ -59,7 +64,9 @@ class ReportsTreeModel(TreeItemModel):
             if isinstance(node, CharacterReportNode):
                 return IconRegistry.character_icon()
             if isinstance(node, CharacterArcReportNode):
-                return IconRegistry.emotion_icon_from_feeling(VERY_UNHAPPY)
+                return IconRegistry.emotion_icon_from_feeling(HAPPY)
+            if isinstance(node, StakesReportNode):
+                return IconRegistry.from_name('mdi.gauge-full', '#ba181b')
             if isinstance(node, ConflictReportNode):
                 return IconRegistry.conflict_icon()
             if isinstance(node, PlotReportNode):

--- a/src/main/python/plotlyst/view/report/conflict.py
+++ b/src/main/python/plotlyst/view/report/conflict.py
@@ -18,7 +18,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 from functools import partial
-from typing import Optional, Dict
+from typing import Dict
 
 from PyQt5.QtChart import QPieSeries
 from PyQt5.QtGui import QColor, QCursor
@@ -28,6 +28,7 @@ from overrides import overrides
 from src.main.python.plotlyst.common import CONFLICT_CHARACTER_COLOR, CONFLICT_NATURE_COLOR, CONFLICT_TECHNOLOGY_COLOR, \
     CONFLICT_SOCIETY_COLOR, CONFLICT_SUPERNATURAL_COLOR, CONFLICT_SELF_COLOR
 from src.main.python.plotlyst.core.domain import Novel, Character, ConflictType
+from src.main.python.plotlyst.core.text import html
 from src.main.python.plotlyst.view.common import icon_to_html_img
 from src.main.python.plotlyst.view.generated.report.conflict_report_ui import Ui_ConflictReport
 from src.main.python.plotlyst.view.icons import IconRegistry
@@ -50,7 +51,6 @@ class ConflictReport(AbstractReport, Ui_ConflictReport):
         self.chartEnneagram = EnneagramChart()
         self.chartViewEnneagram.setChart(self.chartEnneagram)
 
-        self.character: Optional[Character] = None
         self.display()
 
     @overrides
@@ -60,8 +60,7 @@ class ConflictReport(AbstractReport, Ui_ConflictReport):
     def _characterChanged(self, character: Character, toggled: bool):
         if not toggled:
             return
-        self.character = character
-        self.chartType.refresh(self.character)
+        self.chartType.refresh(character)
 
         conflicting_characters = []
         for scene in self.novel.scenes:
@@ -82,7 +81,7 @@ class ConflictTypeChart(BaseChart):
         super(ConflictTypeChart, self).__init__(parent)
         self.novel = novel
         self.legend().hide()
-        self.setTitle('<b>Conflict types<b>')
+        self.setTitle(html('Conflict types').bold())
 
     def refresh(self, character: Character):
         conflicts: Dict[ConflictType, int] = {}
@@ -104,8 +103,7 @@ class ConflictTypeChart(BaseChart):
                 slice_.setColor(QColor(self._colorForType(k)))
                 slice_.hovered.connect(partial(self._hovered, k))
 
-        if self.series():
-            self.removeAllSeries()
+        self.reset()
         self.addSeries(series)
 
     def _hovered(self, conflictType: ConflictType, state: bool):

--- a/src/main/python/plotlyst/view/report/plot.py
+++ b/src/main/python/plotlyst/view/report/plot.py
@@ -87,25 +87,19 @@ class PlotValuesArcChart(BaseChart):
         self.createDefaultAxes()
         self.legend().setMarkerShape(QLegend.MarkerShapeCircle)
         self.legend().show()
-        self.axisX: Optional[QValueAxis] = None
-        self.axisY: Optional[QValueAxis] = None
 
         self.setTitle('Plot value charges')
 
     def refresh(self, plots: List[Plot]):
-        self.removeAllSeries()
-        if self.axisX:
-            self.removeAxis(self.axisX)
-        if self.axisY:
-            self.removeAxis(self.axisY)
+        self.reset()
 
-        self.axisX = QValueAxis()
-        self.axisX.setRange(0, len(self.novel.scenes))
-        self.setAxisX(self.axisX)
-        self.axisX.setVisible(False)
+        axisX = QValueAxis()
+        axisX.setRange(0, len(self.novel.scenes))
+        self.setAxisX(axisX)
+        axisX.setVisible(False)
 
-        self.axisY = QValueAxis()
-        self.setAxisY(self.axisY)
+        axisY = QValueAxis()
+        self.setAxisY(axisY)
 
         min_ = 0
         max_ = 0
@@ -134,10 +128,10 @@ class PlotValuesArcChart(BaseChart):
                 max_ = max(max([x.y() for x in points]), max_)
 
                 self.addSeries(series)
-                series.attachAxis(self.axisX)
-                series.attachAxis(self.axisY)
+                series.attachAxis(axisX)
+                series.attachAxis(axisY)
 
         limit = max(abs(min_), max_)
 
-        self.axisY.setRange(-limit - 3, limit + 3)
-        self.axisY.setVisible(False)
+        axisY.setRange(-limit - 3, limit + 3)
+        axisY.setVisible(False)

--- a/src/main/python/plotlyst/view/report/stakes.py
+++ b/src/main/python/plotlyst/view/report/stakes.py
@@ -1,0 +1,129 @@
+"""
+Plotlyst
+Copyright (C) 2021-2022  Zsolt Kovari
+
+This file is part of Plotlyst.
+
+Plotlyst is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Plotlyst is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+from typing import Dict
+
+from PyQt5.QtChart import QLegend, QValueAxis, QSplineSeries
+from PyQt5.QtGui import QPen, QColor
+from overrides import overrides
+
+from src.main.python.plotlyst.core.domain import Novel, Character, Stake
+from src.main.python.plotlyst.core.text import html
+from src.main.python.plotlyst.view.common import icon_to_html_img
+from src.main.python.plotlyst.view.generated.report.stakes_report_ui import Ui_StakesReport
+from src.main.python.plotlyst.view.icons import IconRegistry
+from src.main.python.plotlyst.view.report import AbstractReport
+from src.main.python.plotlyst.view.widget.chart import BaseChart
+
+
+class StakesReport(AbstractReport, Ui_StakesReport):
+    def __init__(self, novel: Novel, parent=None):
+        super(StakesReport, self).__init__(novel, parent)
+        self.wdgCharacterSelector.characterToggled.connect(self._characterChanged)
+        self.chartStakes = StakesChart(self.novel)
+        self.chartViewStakes.setChart(self.chartStakes)
+
+        self.display()
+
+    @overrides
+    def display(self):
+        self.wdgCharacterSelector.setCharacters(self.novel.agenda_characters(), checkAll=False)
+
+    def _characterChanged(self, character: Character, toggled: bool):
+        if not toggled:
+            return
+
+        self.chartStakes.refresh(character)
+
+
+class StakesChart(BaseChart):
+    def __init__(self, novel: Novel, parent=None):
+        super(StakesChart, self).__init__(parent)
+        self.novel = novel
+        self.legend().setMarkerShape(QLegend.MarkerShapeCircle)
+        self.legend().show()
+        self.setTitle(html('Stakes').bold())
+
+    def refresh(self, character: Character):
+        self.reset()
+
+        axisX = QValueAxis()
+        axisX.setRange(0, len(self.novel.scenes))
+        self.setAxisX(axisX)
+        axisX.setVisible(False)
+
+        axisY = QValueAxis()
+        axisY.setRange(0, 10)
+        self.setAxisY(axisY)
+        axisY.setVisible(False)
+
+        splines: Dict[int, QSplineSeries] = {}
+
+        for i, scene in enumerate(self.novel.scenes):
+            if scene.agendas[0].character_id == character.id:
+                for goal_ref in scene.agendas[0].goal_references:
+                    for k, v in goal_ref.stakes.items():
+                        self._spline(splines, k).append(i + 1, v)
+
+        for series in splines.values():
+            self.addSeries(series)
+            series.attachAxis(axisX)
+            series.attachAxis(axisY)
+
+    def _spline(self, splines: Dict[int, QSplineSeries], stake: int):
+        if stake in splines.keys():
+            return splines[stake]
+
+        series = QSplineSeries()
+        splines[stake] = series
+
+        if stake == Stake.PHYSIOLOGICAL:
+            text = 'Physiological'
+            icon_name = 'mdi.water'
+            color = '#023e8a'
+        elif stake == Stake.SAFETY:
+            text = 'Security'
+            icon_name = 'mdi.shield-half-full'
+            color = '#8900f2'
+        elif stake == Stake.BELONGING:
+            text = 'Belonging'
+            icon_name = 'fa5s.hand-holding-heart'
+            color = '#d00000'
+        elif stake == Stake.ESTEEM:
+            text = 'Esteem'
+            icon_name = 'fa5s.award'
+            color = '#00b4d8'
+        elif stake == Stake.SELF_ACTUALIZATION:
+            text = 'Self-actualization'
+            icon_name = 'mdi.yoga'
+            color = '#52b788'
+        elif stake == Stake.SELF_TRANSCENDENCE:
+            text = 'Self-transcendence'
+            icon_name = 'mdi6.meditation'
+            color = '#c38e70'
+        else:
+            return series
+
+        series.setName(icon_to_html_img(IconRegistry.from_name(icon_name, color)) + text)
+        pen = QPen()
+        pen.setColor(QColor(color))
+        pen.setWidth(2)
+        series.setPen(pen)
+
+        return series

--- a/src/main/python/plotlyst/view/report/stakes.py
+++ b/src/main/python/plotlyst/view/report/stakes.py
@@ -74,11 +74,20 @@ class StakesChart(BaseChart):
         axisY.setVisible(False)
 
         splines: Dict[int, QSplineSeries] = {}
+        char_goals: Dict[str, Dict[int, int]] = {}
 
         for i, scene in enumerate(self.novel.scenes):
             if scene.agendas[0].character_id == character.id:
                 for goal_ref in scene.agendas[0].goal_references:
-                    for k, v in goal_ref.stakes.items():
+                    stakes = goal_ref.stakes
+                    if stakes.keys():
+                        char_goals[str(goal_ref.character_goal_id)] = stakes
+                    elif str(goal_ref.character_goal_id) in char_goals.keys():
+                        stakes = char_goals[str(goal_ref.character_goal_id)]
+
+                    for k, v in stakes.items():
+                        if v == 0:
+                            continue
                         self._spline(splines, k).append(i + 1, v)
 
         for series in splines.values():

--- a/src/main/python/plotlyst/view/reports_view.py
+++ b/src/main/python/plotlyst/view/reports_view.py
@@ -25,13 +25,14 @@ from src.main.python.plotlyst.core.domain import Novel
 from src.main.python.plotlyst.events import CharacterChangedEvent, SceneChangedEvent, SceneDeletedEvent, \
     PlotCreatedEvent
 from src.main.python.plotlyst.model.report import ReportsTreeModel, CharacterReportNode, CharacterArcReportNode, \
-    ConflictReportNode, PlotReportNode
+    ConflictReportNode, PlotReportNode, StakesReportNode
 from src.main.python.plotlyst.view._view import AbstractNovelView
 from src.main.python.plotlyst.view.generated.reports_view_ui import Ui_ReportsView
 from src.main.python.plotlyst.view.report import AbstractReport
 from src.main.python.plotlyst.view.report.character import CharacterReport, CharacterArcReport
 from src.main.python.plotlyst.view.report.conflict import ConflictReport
 from src.main.python.plotlyst.view.report.plot import PlotReport
+from src.main.python.plotlyst.view.report.stakes import StakesReport
 
 
 class ReportsView(AbstractNovelView):
@@ -59,6 +60,9 @@ class ReportsView(AbstractNovelView):
     def displayArcReport(self):
         self._displayReport(CharacterArcReport(self.novel, self.ui.wdgReportContainer))
 
+    def displayStakesReport(self):
+        self._displayReport(StakesReport(self.novel, self.ui.wdgReportContainer))
+
     def displayConflictReport(self):
         self._displayReport(ConflictReport(self.novel, self.ui.wdgReportContainer))
 
@@ -77,6 +81,8 @@ class ReportsView(AbstractNovelView):
             self.displayCharactersReport()
         elif isinstance(node, CharacterArcReportNode):
             self.displayArcReport()
+        elif isinstance(node, StakesReportNode):
+            self.displayStakesReport()
         elif isinstance(node, ConflictReportNode):
             self.displayConflictReport()
         elif isinstance(node, PlotReportNode):

--- a/src/main/python/plotlyst/view/widget/characters.py
+++ b/src/main/python/plotlyst/view/widget/characters.py
@@ -63,6 +63,7 @@ from src.main.python.plotlyst.view.generated.character_goal_widget_ui import Ui_
 from src.main.python.plotlyst.view.generated.character_role_selector_ui import Ui_CharacterRoleSelector
 from src.main.python.plotlyst.view.generated.characters_progress_widget_ui import Ui_CharactersProgressWidget
 from src.main.python.plotlyst.view.generated.scene_dstribution_widget_ui import Ui_CharactersScenesDistributionWidget
+from src.main.python.plotlyst.view.generated.scene_goal_stakes_ui import Ui_GoalReferenceStakesEditor
 from src.main.python.plotlyst.view.icons import avatars, IconRegistry, set_avatar
 from src.main.python.plotlyst.view.widget.display import IconText
 from src.main.python.plotlyst.view.widget.input import DocumentTextEditor
@@ -461,6 +462,17 @@ class CharacterConflictSelector(QWidget):
         gc(self)
 
 
+class GoalStakesEditor(QWidget, Ui_GoalReferenceStakesEditor):
+    def __init__(self, goalRef: GoalReference, parent=None):
+        super(GoalStakesEditor, self).__init__(parent)
+        self.setupUi(self)
+        self.goalRef = goalRef
+
+    @overrides
+    def mouseReleaseEvent(self, event: QMouseEvent) -> None:
+        pass
+
+
 class CharacterGoalSelector(QWidget):
     goalSelected = pyqtSignal()
 
@@ -519,13 +531,6 @@ class CharacterGoalSelector(QWidget):
         self.layout().addWidget(self.label)
         self.btnLinkGoal.setHidden(True)
 
-    # def _plotValueClicked(self):
-    #     menu = QMenu(self.label)
-    #     action = QWidgetAction(menu)
-    #     action.setDefaultWidget(ScenePlotValueEditor(self.plotValue))
-    #     menu.addAction(action)
-    #     menu.popup(QCursor.pos())
-
     def _goalSelected(self, characterGoal: CharacterGoal):
         goal_ref = GoalReference(characterGoal.id)
         self.scene.agendas[0].goal_references.append(goal_ref)
@@ -537,7 +542,7 @@ class CharacterGoalSelector(QWidget):
     def _goalRefClicked(self):
         menu = QMenu(self.label)
         action = QWidgetAction(menu)
-        action.setDefaultWidget(QLabel('Test popup'))
+        action.setDefaultWidget(GoalStakesEditor(self.goalRef))
         menu.addAction(action)
         menu.popup(QCursor.pos())
 

--- a/src/main/python/plotlyst/view/widget/characters.py
+++ b/src/main/python/plotlyst/view/widget/characters.py
@@ -39,7 +39,7 @@ from qthandy.filter import InstantTooltipEventFilter
 from src.main.python.plotlyst.common import RELAXED_WHITE_COLOR
 from src.main.python.plotlyst.core.domain import Novel, Character, Conflict, ConflictType, BackstoryEvent, \
     VERY_HAPPY, HAPPY, UNHAPPY, VERY_UNHAPPY, Scene, NEUTRAL, SceneStructureAgenda, ConflictReference, \
-    CharacterGoal, Goal, GoalReference
+    CharacterGoal, Goal, GoalReference, Stake
 from src.main.python.plotlyst.core.template import secondary_role, guide_role, love_interest_role, sidekick_role, \
     contagonist_role, confidant_role, foil_role, supporter_role, adversary_role, antagonist_role, henchmen_role, \
     tertiary_role, SelectionItem, Role, TemplateFieldType, TemplateField, protagonist_role, RoleImportance
@@ -467,10 +467,36 @@ class GoalStakesEditor(QWidget, Ui_GoalReferenceStakesEditor):
         super(GoalStakesEditor, self).__init__(parent)
         self.setupUi(self)
         self.goalRef = goalRef
+        self.refresh()
+
+        self.sliderPhysiological.valueChanged.connect(partial(self._stakeChanged, Stake.PHYSIOLOGICAL))
+        self.sliderSecurity.valueChanged.connect(partial(self._stakeChanged, Stake.SAFETY))
+        self.sliderBelonging.valueChanged.connect(partial(self._stakeChanged, Stake.BELONGING))
+        self.sliderEsteem.valueChanged.connect(partial(self._stakeChanged, Stake.ESTEEM))
+        self.sliderActualization.valueChanged.connect(partial(self._stakeChanged, Stake.SELF_ACTUALIZATION))
+        self.sliderTranscendence.valueChanged.connect(partial(self._stakeChanged, Stake.SELF_TRANSCENDENCE))
 
     @overrides
     def mouseReleaseEvent(self, event: QMouseEvent) -> None:
         pass
+
+    def refresh(self):
+        for k, v in self.goalRef.stakes.items():
+            if k == Stake.PHYSIOLOGICAL:
+                self.sliderPhysiological.setValue(v)
+            elif k == Stake.SAFETY:
+                self.sliderSecurity.setValue(v)
+            elif k == Stake.BELONGING:
+                self.sliderBelonging.setValue(v)
+            elif k == Stake.ESTEEM:
+                self.sliderEsteem.setValue(v)
+            elif k == Stake.SELF_ACTUALIZATION:
+                self.sliderActualization.setValue(v)
+            elif k == Stake.SELF_TRANSCENDENCE:
+                self.sliderTranscendence.setValue(v)
+
+    def _stakeChanged(self, stake: int, value: int):
+        self.goalRef.stakes[stake] = value
 
 
 class CharacterGoalSelector(QWidget):

--- a/src/main/python/plotlyst/view/widget/input.py
+++ b/src/main/python/plotlyst/view/widget/input.py
@@ -498,7 +498,6 @@ class DocumentTextEditor(RichTextEditor):
     @overrides
     def eventFilter(self, watched: QObject, event: QEvent) -> bool:
         if isinstance(event, QKeyEvent) and event.type() == QEvent.KeyPress:
-            cursor: QTextCursor = self.textEdit.textCursor()
             if event.key() == Qt.Key_Slash:
                 if self.textEdit.textCursor().atBlockStart():
                     self._showCommands()

--- a/src/main/python/plotlyst/view/widget/labels.py
+++ b/src/main/python/plotlyst/view/widget/labels.py
@@ -28,7 +28,7 @@ from qthandy import hbox, FlowLayout, vline, vbox, clear_layout, transparent, bt
 
 from src.main.python.plotlyst.common import truncate_string
 from src.main.python.plotlyst.core.domain import Character, Conflict, SelectionItem, Novel, ScenePlotReference, \
-    CharacterGoal, PlotValue, Scene
+    CharacterGoal, PlotValue, Scene, GoalReference
 from src.main.python.plotlyst.env import app_env
 from src.main.python.plotlyst.model.common import SelectionItemsModel
 from src.main.python.plotlyst.view.common import text_color_with_bg_color, VisibilityToggleEventFilter
@@ -248,8 +248,10 @@ class ScenePlotValueLabel(PlotLabel):
 
 
 class CharacterGoalLabel(SelectionItemLabel):
-    def __init__(self, novel: Novel, characterGoal: CharacterGoal, parent=None, removalEnabled: bool = False):
+    def __init__(self, novel: Novel, characterGoal: CharacterGoal, goalRef: GoalReference, parent=None,
+                 removalEnabled: bool = False):
         super(CharacterGoalLabel, self).__init__(characterGoal.goal(novel), parent, removalEnabled)
+        self.goalRef = goalRef
 
         self.lblGoal = QLabel()
         self.lblGoal.setPixmap(IconRegistry.goal_icon().pixmap(QSize(24, 24)))

--- a/src/main/python/plotlyst/view/widget/scenes.py
+++ b/src/main/python/plotlyst/view/widget/scenes.py
@@ -43,8 +43,8 @@ from src.main.python.plotlyst.common import truncate_string
 from src.main.python.plotlyst.core.client import json_client
 from src.main.python.plotlyst.core.domain import Scene, Novel, SceneType, \
     SceneStructureItemType, SceneStructureAgenda, SceneStructureItem, SceneOutcome, StoryBeat, Conflict, \
-    Character, Plot, ScenePlotReference, CharacterGoal, Chapter, StoryBeatType, Tag, PlotValue, ScenePlotValueCharge, \
-    SceneStage
+    Character, Plot, ScenePlotReference, Chapter, StoryBeatType, Tag, PlotValue, ScenePlotValueCharge, \
+    SceneStage, GoalReference, CharacterGoal
 from src.main.python.plotlyst.env import app_env
 from src.main.python.plotlyst.event.core import emit_critical, emit_event, Event, EventListener
 from src.main.python.plotlyst.event.handler import event_dispatcher
@@ -256,7 +256,7 @@ class ScenePlotSelector(QWidget):
     def setPlot(self, plotValue: ScenePlotReference):
         self.plotValue = plotValue
         self.label = ScenePlotValueLabel(plotValue)
-        self.label.setCursor(Qt.PointingHandCursor)
+        pointy(self.label)
         self.label.clicked.connect(self._plotValueClicked)
 
         self.label.removalRequested.connect(self._remove)
@@ -990,8 +990,10 @@ class SceneStructureWidget(QWidget, Ui_SceneStructureWidget):
             return
         clear_layout(self.wdgGoalConflictContainer)
         if self.scene.agendas[0].goal_references:
-            for char_goal in self.scene.agendas[0].goals(self.scene.agendas[0].character(self.novel)):
-                self._addGoalSelector(char_goal)
+            for goal_ref in self.scene.agendas[0].goal_references:
+                goal = goal_ref.goal(self.scene.agendas[0].character(self.novel))
+                if goal:
+                    self._addGoalSelector(goal, goal_ref)
             self._addGoalSelector()
         else:
             self._addGoalSelector()
@@ -1003,13 +1005,13 @@ class SceneStructureWidget(QWidget, Ui_SceneStructureWidget):
         else:
             self._addConfictSelector()
 
-    def _addGoalSelector(self, charGoal: Optional[CharacterGoal] = None):
+    def _addGoalSelector(self, goal: Optional[CharacterGoal] = None, goalRef: Optional[GoalReference] = None):
         simplified = len(self.scene.agendas[0].goal_references) > 0
         selector = CharacterGoalSelector(self.novel, self.scene, simplified=simplified)
         self.wdgGoalConflictContainer.layout().addWidget(selector)
         selector.goalSelected.connect(self._initSelectors)
-        if charGoal:
-            selector.setGoal(charGoal)
+        if goal and goalRef:
+            selector.setGoal(goal, goalRef)
 
     def _addConfictSelector(self, conflict: Optional[Conflict] = None):
         simplified = len(self.scene.agendas[0].conflict_references) > 0

--- a/ui/report/stakes_report.ui
+++ b/ui/report/stakes_report.ui
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>StakesReport</class>
+ <widget class="QWidget" name="StakesReport">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>3</number>
+   </property>
+   <property name="leftMargin">
+    <number>2</number>
+   </property>
+   <property name="topMargin">
+    <number>2</number>
+   </property>
+   <property name="rightMargin">
+    <number>2</number>
+   </property>
+   <property name="bottomMargin">
+    <number>2</number>
+   </property>
+   <item>
+    <widget class="CharacterSelectorButtons" name="wdgCharacterSelector" native="true"/>
+   </item>
+   <item>
+    <widget class="ChartView" name="chartViewStakes"/>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ChartView</class>
+   <extends>QGraphicsView</extends>
+   <header>src.main.python.plotlyst.view.widget.display</header>
+  </customwidget>
+  <customwidget>
+   <class>CharacterSelectorButtons</class>
+   <extends>QWidget</extends>
+   <header>src.main.python.plotlyst.view.widget.characters</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/ui/scene_goal_stakes.ui
+++ b/ui/scene_goal_stakes.ui
@@ -1,0 +1,570 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>GoalReferenceStakesEditor</class>
+ <widget class="QWidget" name="GoalReferenceStakesEditor">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>306</width>
+    <height>146</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>2</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>2</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>2</number>
+   </property>
+   <item alignment="Qt::AlignHCenter">
+    <widget class="QLabel" name="label">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+       <underline>false</underline>
+      </font>
+     </property>
+     <property name="text">
+      <string>Stakes</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="leftMargin">
+      <number>50</number>
+     </property>
+     <item>
+      <widget class="IconText" name="icontext_6">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Self-transcendence</string>
+       </property>
+       <property name="iconName" stdset="0">
+        <string>mdi6.meditation</string>
+       </property>
+       <property name="iconColor" stdset="0">
+        <string>#c38e70</string>
+       </property>
+      </widget>
+     </item>
+     <item alignment="Qt::AlignRight">
+      <widget class="QSlider" name="horizontalSlider_6">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>100</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="cursor">
+        <cursorShape>PointingHandCursor</cursorShape>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">QSlider::groove:horizontal {
+    border: 1px solid #999999;
+    height: 6px; /* the groove expands to the size of the slider by default. by giving it a height, it has a fixed size */
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #B1B1B1, stop:1 #c4c4c4);
+    margin: 0px 0;
+}
+
+QSlider::handle:horizontal {
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #b4b4b4, stop:1 #8f8f8f);
+    border: 1px solid #5c5c5c;
+    width: 15px;
+    margin: -3px -1px;
+    border-radius: 3px;
+}
+
+QSlider::add-page:horizontal {
+    background: lightgray;
+}
+
+QSlider::sub-page:horizontal {
+    background: #c38e70;
+}</string>
+       </property>
+       <property name="maximum">
+        <number>10</number>
+       </property>
+       <property name="pageStep">
+        <number>1</number>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <property name="leftMargin">
+      <number>40</number>
+     </property>
+     <item>
+      <widget class="IconText" name="icontext_5">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Self-actualization</string>
+       </property>
+       <property name="iconName" stdset="0">
+        <string>mdi.yoga</string>
+       </property>
+       <property name="iconColor" stdset="0">
+        <string>#52b788</string>
+       </property>
+      </widget>
+     </item>
+     <item alignment="Qt::AlignRight">
+      <widget class="QSlider" name="horizontalSlider_5">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>100</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="cursor">
+        <cursorShape>PointingHandCursor</cursorShape>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">QSlider::groove:horizontal {
+    border: 1px solid #999999;
+    height: 6px; /* the groove expands to the size of the slider by default. by giving it a height, it has a fixed size */
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #B1B1B1, stop:1 #c4c4c4);
+    margin: 0px 0;
+}
+
+QSlider::handle:horizontal {
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #b4b4b4, stop:1 #8f8f8f);
+    border: 1px solid #5c5c5c;
+    width: 15px;
+    margin: -3px -1px;
+    border-radius: 3px;
+}
+
+QSlider::add-page:horizontal {
+    background: lightgray;
+}
+
+QSlider::sub-page:horizontal {
+    background: #52b788;
+}</string>
+       </property>
+       <property name="maximum">
+        <number>10</number>
+       </property>
+       <property name="pageStep">
+        <number>1</number>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <property name="leftMargin">
+      <number>30</number>
+     </property>
+     <item>
+      <widget class="IconText" name="icontext_4">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Esteem and success</string>
+       </property>
+       <property name="iconName" stdset="0">
+        <string>fa5s.award</string>
+       </property>
+       <property name="iconColor" stdset="0">
+        <string>#00b4d8</string>
+       </property>
+      </widget>
+     </item>
+     <item alignment="Qt::AlignRight">
+      <widget class="QSlider" name="horizontalSlider_4">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>100</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="cursor">
+        <cursorShape>PointingHandCursor</cursorShape>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">QSlider::groove:horizontal {
+    border: 1px solid #999999;
+    height: 6px; /* the groove expands to the size of the slider by default. by giving it a height, it has a fixed size */
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #B1B1B1, stop:1 #c4c4c4);
+    margin: 0px 0;
+}
+
+QSlider::handle:horizontal {
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #b4b4b4, stop:1 #8f8f8f);
+    border: 1px solid #5c5c5c;
+    width: 15px;
+    margin: -3px -1px;
+    border-radius: 3px;
+}
+
+QSlider::add-page:horizontal {
+    background: lightgray;
+}
+
+QSlider::sub-page:horizontal {
+    background: #00b4d8;
+}</string>
+       </property>
+       <property name="maximum">
+        <number>10</number>
+       </property>
+       <property name="pageStep">
+        <number>1</number>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <property name="leftMargin">
+      <number>20</number>
+     </property>
+     <item>
+      <widget class="IconText" name="icontext_3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Belonging and love</string>
+       </property>
+       <property name="iconName" stdset="0">
+        <string>fa5s.hand-holding-heart</string>
+       </property>
+       <property name="iconColor" stdset="0">
+        <string>#d00000</string>
+       </property>
+      </widget>
+     </item>
+     <item alignment="Qt::AlignRight">
+      <widget class="QSlider" name="horizontalSlider_3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>100</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="cursor">
+        <cursorShape>PointingHandCursor</cursorShape>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">QSlider::groove:horizontal {
+    border: 1px solid #999999;
+    height: 6px; /* the groove expands to the size of the slider by default. by giving it a height, it has a fixed size */
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #B1B1B1, stop:1 #c4c4c4);
+    margin: 0px 0;
+}
+
+QSlider::handle:horizontal {
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #b4b4b4, stop:1 #8f8f8f);
+    border: 1px solid #5c5c5c;
+    width: 15px;
+    margin: -3px -1px;
+    border-radius: 3px;
+}
+
+QSlider::add-page:horizontal {
+    background: lightgray;
+}
+
+QSlider::sub-page:horizontal {
+    background: #d00000;
+}</string>
+       </property>
+       <property name="maximum">
+        <number>10</number>
+       </property>
+       <property name="pageStep">
+        <number>1</number>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_5">
+     <property name="leftMargin">
+      <number>10</number>
+     </property>
+     <item>
+      <widget class="IconText" name="icontext_2">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">IconText {border: 0px; background-color: rgba(0, 0, 0, 0);}</string>
+       </property>
+       <property name="text">
+        <string>Security and safety</string>
+       </property>
+       <property name="iconName" stdset="0">
+        <string>mdi.shield-half-full</string>
+       </property>
+       <property name="iconColor" stdset="0">
+        <string>#8900f2</string>
+       </property>
+      </widget>
+     </item>
+     <item alignment="Qt::AlignRight">
+      <widget class="QSlider" name="horizontalSlider_2">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>100</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="cursor">
+        <cursorShape>PointingHandCursor</cursorShape>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">QSlider::groove:horizontal {
+    border: 1px solid #999999;
+    height: 6px; /* the groove expands to the size of the slider by default. by giving it a height, it has a fixed size */
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #B1B1B1, stop:1 #c4c4c4);
+    margin: 0px 0;
+}
+
+QSlider::handle:horizontal {
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #b4b4b4, stop:1 #8f8f8f);
+    border: 1px solid #5c5c5c;
+    width: 15px;
+    margin: -3px -1px;
+    border-radius: 3px;
+}
+
+QSlider::add-page:horizontal {
+    background: lightgray;
+}
+
+QSlider::sub-page:horizontal {
+    background: #8900f2;
+}</string>
+       </property>
+       <property name="maximum">
+        <number>10</number>
+       </property>
+       <property name="pageStep">
+        <number>1</number>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_6">
+     <item>
+      <widget class="IconText" name="icontext">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="font">
+        <font>
+         <weight>50</weight>
+         <bold>false</bold>
+        </font>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">IconText {border: 0px; background-color: rgba(0, 0, 0, 0);}</string>
+       </property>
+       <property name="text">
+        <string>Physiological needs</string>
+       </property>
+       <property name="iconName" stdset="0">
+        <string>mdi.water</string>
+       </property>
+       <property name="iconColor" stdset="0">
+        <string>#023e8a</string>
+       </property>
+      </widget>
+     </item>
+     <item alignment="Qt::AlignRight">
+      <widget class="QSlider" name="horizontalSlider">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>100</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="cursor">
+        <cursorShape>PointingHandCursor</cursorShape>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">QSlider::groove:horizontal {
+    border: 1px solid #999999;
+    height: 6px; /* the groove expands to the size of the slider by default. by giving it a height, it has a fixed size */
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #B1B1B1, stop:1 #c4c4c4);
+    margin: 0px 0;
+}
+
+QSlider::handle:horizontal {
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #b4b4b4, stop:1 #8f8f8f);
+    border: 1px solid #5c5c5c;
+    width: 15px;
+    margin: -3px -1px;
+    border-radius: 3px;
+}
+
+QSlider::add-page:horizontal {
+    background: lightgray;
+}
+
+QSlider::sub-page:horizontal {
+    background: #023e8a;
+}</string>
+       </property>
+       <property name="maximum">
+        <number>10</number>
+       </property>
+       <property name="pageStep">
+        <number>1</number>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>IconText</class>
+   <extends>QPushButton</extends>
+   <header>src.main.python.plotlyst.view.widget.display</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/ui/scene_goal_stakes.ui
+++ b/ui/scene_goal_stakes.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>306</width>
-    <height>146</height>
+    <height>165</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -68,7 +68,7 @@
       </widget>
      </item>
      <item alignment="Qt::AlignRight">
-      <widget class="QSlider" name="horizontalSlider_6">
+      <widget class="QSlider" name="sliderTranscendence">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -152,7 +152,7 @@ QSlider::sub-page:horizontal {
       </widget>
      </item>
      <item alignment="Qt::AlignRight">
-      <widget class="QSlider" name="horizontalSlider_5">
+      <widget class="QSlider" name="sliderActualization">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -236,7 +236,7 @@ QSlider::sub-page:horizontal {
       </widget>
      </item>
      <item alignment="Qt::AlignRight">
-      <widget class="QSlider" name="horizontalSlider_4">
+      <widget class="QSlider" name="sliderEsteem">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -320,7 +320,7 @@ QSlider::sub-page:horizontal {
       </widget>
      </item>
      <item alignment="Qt::AlignRight">
-      <widget class="QSlider" name="horizontalSlider_3">
+      <widget class="QSlider" name="sliderBelonging">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -407,7 +407,7 @@ QSlider::sub-page:horizontal {
       </widget>
      </item>
      <item alignment="Qt::AlignRight">
-      <widget class="QSlider" name="horizontalSlider_2">
+      <widget class="QSlider" name="sliderSecurity">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -497,7 +497,7 @@ QSlider::sub-page:horizontal {
       </widget>
      </item>
      <item alignment="Qt::AlignRight">
-      <widget class="QSlider" name="horizontalSlider">
+      <widget class="QSlider" name="sliderPhysiological">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
          <horstretch>0</horstretch>

--- a/ui/scene_structure_editor_widget.ui
+++ b/ui/scene_structure_editor_widget.ui
@@ -125,6 +125,13 @@
             </widget>
            </item>
            <item>
+            <widget class="Line" name="line">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+            </widget>
+           </item>
+           <item>
             <widget class="QWidget" name="wdgGoalConflictContainer" native="true">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
@@ -319,7 +326,7 @@
            <property name="minimumSize">
             <size>
              <width>73</width>
-             <height>40</height>
+             <height>73</height>
             </size>
            </property>
           </widget>


### PR DESCRIPTION
- [x] scenegoal ref label
- [x] maslow stakes sliders in popup
- [x] persist stakes
- [x] restore stakes
- [x] inherit previous stakes by default for same goal
- [ ] optionally inherit stakes from parent
- [ ] visualize overall stakes per story
- [x] visualize overall stakes per character
- [ ] visualize stakes and types per character goal