### PR TITLE
Remove Novel reloads and update_from usages, closes #341

### DIFF
--- a/src/main/python/plotlyst/core/domain.py
+++ b/src/main/python/plotlyst/core/domain.py
@@ -442,11 +442,14 @@ class PlotPrinciple:
 class CharacterBased(ABC):
     def set_character(self, character: Optional[Character]):
         if character is None:
-            self.character_id = None
-            self._character = None
+            self.reset_character()
         else:
             self.character_id = character.id
             self._character = character
+
+    def reset_character(self):
+        self.character_id = None
+        self._character = None
 
     def character(self, novel: 'Novel') -> Optional[Character]:
         if not self.character_id:

--- a/src/main/python/plotlyst/core/domain.py
+++ b/src/main/python/plotlyst/core/domain.py
@@ -1346,28 +1346,6 @@ class Novel(NovelDescriptor):
     world: WorldBuilding = WorldBuilding()
     board: Board = Board()
 
-    def update_from(self, updated_novel: 'Novel'):
-        self.title = updated_novel.title
-        self.scenes.clear()
-        self.scenes.extend(updated_novel.scenes)
-        self.characters.clear()
-        self.characters.extend(updated_novel.characters)
-        self.chapters.clear()
-        self.chapters.extend(updated_novel.chapters)
-        self.plots.clear()
-        self.plots.extend(updated_novel.plots)
-        self.stages.clear()
-        self.stages.extend(updated_novel.stages)
-        self.character_profiles.clear()
-        self.character_profiles.extend(updated_novel.character_profiles)
-        self.conflicts.clear()
-        self.conflicts.extend(updated_novel.conflicts)
-        self.goals.clear()
-        self.goals.extend(updated_novel.goals)
-        self.tags.clear()
-        for k in updated_novel.tags:
-            self.tags[k] = updated_novel.tags[k]
-
     def pov_characters(self) -> List[Character]:
         pov_ids = set()
         povs: List[Character] = []

--- a/src/main/python/plotlyst/events.py
+++ b/src/main/python/plotlyst/events.py
@@ -30,6 +30,7 @@ class NovelReloadRequestedEvent(Event):
     pass
 
 
+# remove
 @dataclass
 class NovelReloadedEvent(Event):
     pass

--- a/src/main/python/plotlyst/events.py
+++ b/src/main/python/plotlyst/events.py
@@ -26,18 +26,12 @@ from src.main.python.plotlyst.event.core import Event
 
 
 @dataclass
-class NovelReloadRequestedEvent(Event):
-    pass
-
-
-# remove
-@dataclass
-class NovelReloadedEvent(Event):
-    pass
-
-
-@dataclass
 class CharacterChangedEvent(Event):
+    character: Character
+
+
+@dataclass
+class CharacterDeletedEvent(Event):
     character: Character
 
 

--- a/src/main/python/plotlyst/view/_view.py
+++ b/src/main/python/plotlyst/view/_view.py
@@ -28,7 +28,7 @@ from qthandy import busy
 from src.main.python.plotlyst.core.domain import Novel
 from src.main.python.plotlyst.event.core import EventListener, Event
 from src.main.python.plotlyst.event.handler import event_dispatcher
-from src.main.python.plotlyst.events import NovelReloadedEvent
+from src.main.python.plotlyst.events import CharacterDeletedEvent
 from src.main.python.plotlyst.service.persistence import RepositoryPersistenceManager
 
 
@@ -81,7 +81,7 @@ class AbstractNovelView(AbstractView):
             events = event_types
         else:
             events = []
-        events.append(NovelReloadedEvent)
+        events.append(CharacterDeletedEvent)
         super().__init__(events)
         self.novel = novel
 

--- a/src/main/python/plotlyst/view/characters_view.py
+++ b/src/main/python/plotlyst/view/characters_view.py
@@ -29,7 +29,8 @@ from src.main.python.plotlyst.common import RELAXED_WHITE_COLOR
 from src.main.python.plotlyst.core.domain import Novel, Character
 from src.main.python.plotlyst.event.core import emit_event, EventListener, Event
 from src.main.python.plotlyst.event.handler import event_dispatcher
-from src.main.python.plotlyst.events import NovelReloadRequestedEvent, CharacterChangedEvent, ToggleOutlineViewTitle
+from src.main.python.plotlyst.events import CharacterChangedEvent, ToggleOutlineViewTitle, \
+    CharacterDeletedEvent
 from src.main.python.plotlyst.model.characters_model import CharactersTableModel
 from src.main.python.plotlyst.model.common import proxy
 from src.main.python.plotlyst.resources import resource_registry
@@ -57,7 +58,7 @@ class CharactersTitle(QWidget, Ui_CharactersTitle, EventListener):
         self.refresh()
 
         event_dispatcher.register(self, CharacterChangedEvent)
-        event_dispatcher.register(self, NovelReloadRequestedEvent)
+        event_dispatcher.register(self, CharacterDeletedEvent)
 
     @overrides
     def event_received(self, event: Event):
@@ -265,7 +266,7 @@ class CharactersView(AbstractNovelView):
         self.novel.characters.remove(character)
         self.ui.wdgCharacterSelector.removeCharacter(character)
         self.repo.delete_character(self.novel, character)
-        emit_event(NovelReloadRequestedEvent(self))
+        emit_event(CharacterDeletedEvent(self, character))
         self.refresh()
 
     @busy

--- a/src/main/python/plotlyst/view/scenes_view.py
+++ b/src/main/python/plotlyst/view/scenes_view.py
@@ -248,7 +248,7 @@ class ScenesOutlineView(AbstractNovelView):
                             break
                     for agenda in scene.agendas:
                         if agenda.character_id == char_id:
-                            agenda.character_id = None
+                            agenda.reset_character()
                             agenda.conflict_references.clear()
                             agenda.goal_references.clear()
                             update_scene = True

--- a/src/main/python/plotlyst/view/scenes_view.py
+++ b/src/main/python/plotlyst/view/scenes_view.py
@@ -34,7 +34,7 @@ from src.main.python.plotlyst.event.core import emit_event, EventListener
 from src.main.python.plotlyst.event.handler import event_dispatcher
 from src.main.python.plotlyst.events import SceneChangedEvent, SceneDeletedEvent, NovelStoryStructureUpdated, \
     SceneSelectedEvent, SceneSelectionClearedEvent, ToggleOutlineViewTitle, ActiveSceneStageChanged, \
-    ChapterChangedEvent, AvailableSceneStagesChanged
+    ChapterChangedEvent, AvailableSceneStagesChanged, CharacterChangedEvent, CharacterDeletedEvent
 from src.main.python.plotlyst.events import SceneOrderChangedEvent
 from src.main.python.plotlyst.model.common import SelectionItemsModel
 from src.main.python.plotlyst.model.novel import NovelStagesModel
@@ -217,15 +217,55 @@ class ScenesOutlineView(AbstractNovelView):
         self.ui.btnDelete.clicked.connect(self._on_delete)
 
         self.ui.cards.swapped.connect(self._scenes_swapped)
+        event_dispatcher.register(self, CharacterChangedEvent)
+        event_dispatcher.register(self, CharacterDeletedEvent)
 
-    #     event_dispatcher.register(self, CharacterChangedEvent)
-    #
-    # @overrides
-    # def event_received(self, event: Event):
-    #     if isinstance(event, CharacterChangedEvent):
-    #         self._scene_filter.povFilter.updateCharacters(self.novel.pov_characters(), checkAll=True)
-    #     else:
-    #         super(ScenesOutlineView, self).event_received(event)
+    @overrides
+    def event_received(self, event: Event):
+        if isinstance(event, (CharacterChangedEvent, CharacterDeletedEvent)):
+            self._scene_filter.povFilter.updateCharacters(self.novel.pov_characters(), checkAll=True)
+            if isinstance(event, CharacterDeletedEvent):
+                char_id = event.character.id
+                removed_conflicts = []
+                for conflict in self.novel.conflicts:
+                    if conflict.character_id == char_id or conflict.conflicting_character_id == char_id:
+                        removed_conflicts.append(conflict)
+                for conf in removed_conflicts:
+                    self.novel.conflicts.remove(conf)
+                if removed_conflicts:
+                    self.repo.update_novel(self.novel)
+                removed_conflicts = [x.id for x in removed_conflicts]
+
+                for scene in self.novel.scenes:
+                    update_scene = False
+                    if scene.pov is not None and scene.pov.id == char_id:
+                        scene.pov = None
+                        update_scene = True
+                    for char in scene.characters:
+                        if char.id == char_id:
+                            scene.characters.remove(char)
+                            update_scene = True
+                            break
+                    for agenda in scene.agendas:
+                        if agenda.character_id == char_id:
+                            agenda.character_id = None
+                            agenda.conflict_references.clear()
+                            agenda.goal_references.clear()
+                            update_scene = True
+                            continue
+                        if removed_conflicts:
+                            before = len(agenda.conflict_references)
+                            agenda.conflict_references[:] = [x for x in agenda.conflict_references
+                                                             if x.conflict_id not in removed_conflicts]
+                            if before != len(agenda.conflict_references):
+                                update_scene = True
+
+                    if update_scene:
+                        self.repo.update_scene(scene)
+
+            self.refresh()
+        else:
+            super(ScenesOutlineView, self).event_received(event)
 
     @overrides
     def refresh(self):

--- a/src/main/python/plotlyst/view/widget/characters.py
+++ b/src/main/python/plotlyst/view/widget/characters.py
@@ -639,22 +639,11 @@ class CharacterSelectorButton(QToolButton):
 
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.setIcon(IconRegistry.character_icon('grey'))
         pointy(self)
-        self.setStyleSheet('''
-                        QToolButton {
-                            border: 2px dotted grey;
-                            border-radius: 6px;
-                        }
-                        QToolButton:hover {
-                            border: 2px dotted darkBlue;
-                        }
-                    ''')
-        self.setIconSize(QSize(32, 32))
         self._opacityFilter = OpacityEventFilter(self)
-        self.installEventFilter(self._opacityFilter)
         self._menu = QMenu(self)
         btn_popup_menu(self, self._menu)
+        self.clear()
 
     def setAvailableCharacters(self, characters: List[Character]):
         self._menu.clear()
@@ -666,11 +655,23 @@ class CharacterSelectorButton(QToolButton):
     def setCharacter(self, character: Character):
         self.setIcon(avatars.avatar(character))
         transparent(self)
-        if self._opacityFilter:
-            self.removeEventFilter(self._opacityFilter)
-            self._opacityFilter = None
-            translucent(self, 1.0)
-            self.setIconSize(QSize(35, 35))
+        self.removeEventFilter(self._opacityFilter)
+        translucent(self, 1.0)
+        self.setIconSize(QSize(35, 35))
+
+    def clear(self):
+        self.setStyleSheet('''
+                                QToolButton {
+                                    border: 2px dotted grey;
+                                    border-radius: 6px;
+                                }
+                                QToolButton:hover {
+                                    border: 2px dotted darkBlue;
+                                }
+                            ''')
+        self.setIcon(IconRegistry.character_icon('grey'))
+        self.setIconSize(QSize(32, 32))
+        self.installEventFilter(self._opacityFilter)
 
     def _selected(self, character: Character):
         self.setCharacter(character)

--- a/src/main/python/plotlyst/view/widget/novel.py
+++ b/src/main/python/plotlyst/view/widget/novel.py
@@ -38,7 +38,8 @@ from src.main.python.plotlyst.core.domain import StoryStructure, Novel, StoryBea
 from src.main.python.plotlyst.env import app_env
 from src.main.python.plotlyst.event.core import emit_event, EventListener, Event
 from src.main.python.plotlyst.event.handler import event_dispatcher
-from src.main.python.plotlyst.events import NovelStoryStructureUpdated, SceneChangedEvent, SceneDeletedEvent
+from src.main.python.plotlyst.events import NovelStoryStructureUpdated, SceneChangedEvent, SceneDeletedEvent, \
+    CharacterChangedEvent, CharacterDeletedEvent
 from src.main.python.plotlyst.model.characters_model import CharactersTableModel
 from src.main.python.plotlyst.model.common import SelectionItemsModel
 from src.main.python.plotlyst.model.novel import NovelTagsModel
@@ -361,7 +362,7 @@ class StoryStructureSelectorDialog(QDialog, Ui_StoryStructureSelectorDialog):
             return self.pageSaveTheCat, _SaveTheCatActStructureEditorWidget
 
 
-class StoryStructureEditor(QWidget, Ui_StoryStructureSettings):
+class StoryStructureEditor(QWidget, Ui_StoryStructureSettings, EventListener):
     def __init__(self, parent=None):
         super(StoryStructureEditor, self).__init__(parent)
         self.setupUi(self)
@@ -388,6 +389,13 @@ class StoryStructureEditor(QWidget, Ui_StoryStructureSettings):
         self.novel: Optional[Novel] = None
         self.beats.installEventFilter(self)
         self.repo = RepositoryPersistenceManager.instance()
+
+        event_dispatcher.register(self, CharacterChangedEvent)
+        event_dispatcher.register(self, CharacterDeletedEvent)
+
+    @overrides
+    def event_received(self, event: Event):
+        self._activeStructureToggled(self.novel.active_story_structure, True)
 
     @overrides
     def eventFilter(self, watched: QObject, event: QEvent) -> bool:

--- a/src/main/python/plotlyst/view/widget/plot.py
+++ b/src/main/python/plotlyst/view/widget/plot.py
@@ -37,7 +37,7 @@ from src.main.python.plotlyst.core.template import antagonist_role
 from src.main.python.plotlyst.env import app_env
 from src.main.python.plotlyst.event.core import EventListener, Event
 from src.main.python.plotlyst.event.handler import event_dispatcher
-from src.main.python.plotlyst.events import CharacterChangedEvent
+from src.main.python.plotlyst.events import CharacterChangedEvent, CharacterDeletedEvent
 from src.main.python.plotlyst.service.persistence import RepositoryPersistenceManager, delete_plot
 from src.main.python.plotlyst.settings import STORY_LINE_COLOR_CODES
 from src.main.python.plotlyst.view.common import action, restyle, pointy
@@ -234,10 +234,15 @@ class PlotWidget(QFrame, Ui_PlotWidget, EventListener):
         self.repo = RepositoryPersistenceManager.instance()
 
         event_dispatcher.register(self, CharacterChangedEvent)
+        event_dispatcher.register(self, CharacterDeletedEvent)
 
     def event_received(self, event: Event):
-        if isinstance(event, CharacterChangedEvent):
-            self._characterSelector.setAvailableCharacters(self.novel.characters)
+        self._characterSelector.setAvailableCharacters(self.novel.characters)
+        if isinstance(event, CharacterDeletedEvent):
+            if self.plot.character_id == event.character.id:
+                self.plot.character_id = None
+                self.repo.update_novel(self.novel)
+                self._characterSelector.clear()
 
     def _principle(self, principleType: PlotPrincipleType) -> PlotPrinciple:
         for principle in self.plot.principles:

--- a/src/main/python/plotlyst/view/widget/plot.py
+++ b/src/main/python/plotlyst/view/widget/plot.py
@@ -240,7 +240,7 @@ class PlotWidget(QFrame, Ui_PlotWidget, EventListener):
         self._characterSelector.setAvailableCharacters(self.novel.characters)
         if isinstance(event, CharacterDeletedEvent):
             if self.plot.character_id == event.character.id:
-                self.plot.character_id = None
+                self.plot.reset_character()
                 self.repo.update_novel(self.novel)
                 self._characterSelector.clear()
 


### PR DESCRIPTION
NovelReloadRequestedEvent
- [x] char title: register
- [x] char view: emit
- [x] main window: register

NovelReloadedEvent
- [x] abs novel view: register
- [x] main window: register

novel.update_from
- [x] from main window reloaded request

new solution
- [x] add CharacterDeletedEvent
- [ ] handle event in:
  - [x] scene present characters
  - [x] scenes view from conflict
  - [x] scenes view from agenda and pov
  - [x] scenes view from filter
  - [x] characters backstory view
  - [x] characters comparison view
  - [x] novel plot view
  - [x] novel structure view
  - [ ] documents view