### PR TITLE
Separate global event sender and dispatcher from novel-based ones

### DIFF
--- a/src/main/python/plotlyst/core/client.py
+++ b/src/main/python/plotlyst/core/client.py
@@ -528,10 +528,6 @@ class JsonClient:
                       conflicts=conflicts, goals=[x for x in novel_info.goals if str(x.id) in goal_ids], tags=tags_dict,
                       documents=novel_info.documents, premise=novel_info.premise, synopsis=novel_info.synopsis,
                       prefs=novel_info.prefs, manuscript_goals=novel_info.manuscript_goals)
-        for character in novel.characters:
-            character.novel = novel
-        for scene in novel.scenes:
-            scene.novel = novel
 
         world_path = self.novels_dir.joinpath(str(novel_info.id)).joinpath('world.json')
         if os.path.exists(world_path):

--- a/src/main/python/plotlyst/core/client.py
+++ b/src/main/python/plotlyst/core/client.py
@@ -528,6 +528,10 @@ class JsonClient:
                       conflicts=conflicts, goals=[x for x in novel_info.goals if str(x.id) in goal_ids], tags=tags_dict,
                       documents=novel_info.documents, premise=novel_info.premise, synopsis=novel_info.synopsis,
                       prefs=novel_info.prefs, manuscript_goals=novel_info.manuscript_goals)
+        for character in novel.characters:
+            character.novel = novel
+        for scene in novel.scenes:
+            scene.novel = novel
 
         world_path = self.novels_dir.joinpath(str(novel_info.id)).joinpath('world.json')
         if os.path.exists(world_path):

--- a/src/main/python/plotlyst/core/domain.py
+++ b/src/main/python/plotlyst/core/domain.py
@@ -310,7 +310,6 @@ class Character:
     prefs: CharacterPreferences = field(default_factory=CharacterPreferences)
     topics: List[TemplateValue] = field(default_factory=list)
     big_five: Dict[str, List[int]] = field(default_factory=default_big_five_values)
-    novel: Optional['Novel'] = None
 
     def enneagram(self) -> Optional[SelectionItem]:
         for value in self.template_values:
@@ -894,7 +893,6 @@ class Scene:
     document: Optional['Document'] = None
     manuscript: Optional['Document'] = None
     drive: SceneDrive = SceneDrive()
-    novel: Optional['Novel'] = None
 
     def beat(self, novel: 'Novel') -> Optional[StoryBeat]:
         structure = novel.active_story_structure

--- a/src/main/python/plotlyst/core/domain.py
+++ b/src/main/python/plotlyst/core/domain.py
@@ -310,6 +310,7 @@ class Character:
     prefs: CharacterPreferences = field(default_factory=CharacterPreferences)
     topics: List[TemplateValue] = field(default_factory=list)
     big_five: Dict[str, List[int]] = field(default_factory=default_big_five_values)
+    novel: Optional['Novel'] = None
 
     def enneagram(self) -> Optional[SelectionItem]:
         for value in self.template_values:
@@ -893,6 +894,7 @@ class Scene:
     document: Optional['Document'] = None
     manuscript: Optional['Document'] = None
     drive: SceneDrive = SceneDrive()
+    novel: Optional['Novel'] = None
 
     def beat(self, novel: 'Novel') -> Optional[StoryBeat]:
         structure = novel.active_story_structure

--- a/src/main/python/plotlyst/event/core.py
+++ b/src/main/python/plotlyst/event/core.py
@@ -79,6 +79,7 @@ class EventSendersRepository:
     def pop(self, novel: Novel):
         self._senders.pop(novel, None)
 
+
 event_senders = EventSendersRepository()
 
 global_event_sender = EventSender()

--- a/src/main/python/plotlyst/event/core.py
+++ b/src/main/python/plotlyst/event/core.py
@@ -20,9 +20,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from abc import abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional, Any
+from typing import Optional, Any, Dict
 
 from PyQt6.QtCore import pyqtSignal, QObject
+
+from src.main.python.plotlyst.core.domain import Novel
 
 
 class Severity(Enum):
@@ -64,7 +66,22 @@ class EventSender(QObject):
     send = pyqtSignal(Event)
 
 
-event_sender = EventSender()
+class EventSendersRepository:
+    def __init__(self):
+        self._senders: Dict[Novel, EventSender] = {}
+
+    def instance(self, novel: Novel) -> EventSender:
+        if novel not in self._senders.keys():
+            self._senders[novel] = EventSender()
+
+        return self._senders[novel]
+
+    def pop(self, novel: Novel):
+        self._senders.pop(novel, None)
+
+event_senders = EventSendersRepository()
+
+global_event_sender = EventSender()
 
 
 class EventListener:
@@ -74,5 +91,9 @@ class EventListener:
         pass
 
 
-def emit_event(event: Event):
-    event_sender.send.emit(event)
+def emit_global_event(event: Event):
+    global_event_sender.send.emit(event)
+
+
+def emit_event(novel: Novel, event: Event):
+    event_senders.instance(novel).send.emit(event)

--- a/src/main/python/plotlyst/event/handler.py
+++ b/src/main/python/plotlyst/event/handler.py
@@ -26,6 +26,7 @@ from PyQt6.QtCore import QTimer, Qt, QObject
 from PyQt6.QtGui import QCursor
 from PyQt6.QtWidgets import QMessageBox, QWidget, QStatusBar, QApplication
 
+from src.main.python.plotlyst.core.domain import Novel
 from src.main.python.plotlyst.env import app_env
 from src.main.python.plotlyst.event.core import EventLog, Severity, \
     emit_critical, EventListener, Event
@@ -124,4 +125,22 @@ class EventDispatcher:
                     listener.event_received(event)
 
 
-event_dispatcher = EventDispatcher()
+class EventDispatchersRepository:
+    def __init__(self):
+        self._dispatchers: Dict[Novel, EventDispatcher] = {}
+
+    def instance(self, novel: Novel) -> EventDispatcher:
+        if novel not in self._dispatchers.keys():
+            self._dispatchers[novel] = EventDispatcher()
+
+        return self._dispatchers[novel]
+
+    def pop(self, novel: Novel):
+        dispatcher = self._dispatchers.pop(novel, None)
+        if dispatcher:
+            dispatcher.clear()
+
+
+event_dispatchers = EventDispatchersRepository()
+
+global_event_dispatcher = EventDispatcher()

--- a/src/main/python/plotlyst/event/handler.py
+++ b/src/main/python/plotlyst/event/handler.py
@@ -105,8 +105,8 @@ class EventDispatcher:
             if event_type not in self._listeners.keys():
                 self._listeners[event_type] = []
             self._listeners[event_type].append(listener)
-            if isinstance(listener, QObject):
-                listener.destroyed.connect(lambda: self.deregister(listener, event_type))
+        if isinstance(listener, QObject):
+            listener.destroyed.connect(lambda: self.deregister(listener, *event_types))
 
     def clear(self):
         self._listeners.clear()

--- a/src/main/python/plotlyst/model/scenes_model.py
+++ b/src/main/python/plotlyst/model/scenes_model.py
@@ -325,7 +325,7 @@ class ScenesStageTableModel(QAbstractTableModel, BaseScenesTableModel):
 
         RepositoryPersistenceManager.instance().update_scene(scene)
         self.modelReset.emit()
-        emit_event(SceneStatusChangedEvent(self, scene))
+        emit_event(self.novel, SceneStatusChangedEvent(self, scene))
 
     def setHighlightedStage(self, stage: SceneStage):
         self._highlighted_stage = stage

--- a/src/main/python/plotlyst/resources.py
+++ b/src/main/python/plotlyst/resources.py
@@ -30,8 +30,8 @@ from fbs_runtime.application_context.PyQt6 import ApplicationContext
 from overrides import overrides
 
 from src.main.python.plotlyst.env import app_env
-from src.main.python.plotlyst.event.core import EventListener, Event, emit_event
-from src.main.python.plotlyst.event.handler import event_dispatcher
+from src.main.python.plotlyst.event.core import EventListener, Event, emit_global_event
+from src.main.python.plotlyst.event.handler import global_event_dispatcher
 
 
 class ResourceRegistry:
@@ -183,8 +183,8 @@ class ResourceManager(EventListener):
         os.environ.setdefault('PYPANDOC_PANDOC',
                               os.path.join(app_env.cache_dir, _pandoc_resource.folder, _pandoc_resource.name, 'pandoc'))
 
-        event_dispatcher.register(self, ResourceDownloadedEvent)
-        event_dispatcher.register(self, ResourceRemovedEvent)
+        global_event_dispatcher.register(self, ResourceDownloadedEvent)
+        global_event_dispatcher.register(self, ResourceRemovedEvent)
 
     @overrides
     def event_received(self, event: Event):
@@ -233,7 +233,7 @@ class ResourceManager(EventListener):
         info.status = status
         self.save()
 
-        emit_event(ResourceStatusChangedEvent(self, type_, status))
+        emit_global_event(ResourceStatusChangedEvent(self, type_, status))
 
     def __get_resource_info(self, resource_type: ResourceType) -> ResourceInfo:
         if resource_type not in self._resources_config.resources.keys():

--- a/src/main/python/plotlyst/service/cache.py
+++ b/src/main/python/plotlyst/service/cache.py
@@ -23,14 +23,13 @@ from overrides import overrides
 
 from src.main.python.plotlyst.core.domain import Novel, Scene, StoryBeat
 from src.main.python.plotlyst.event.core import EventListener, Event
-from src.main.python.plotlyst.event.handler import event_dispatcher
+from src.main.python.plotlyst.event.handler import event_dispatchers
 from src.main.python.plotlyst.events import SceneChangedEvent, SceneDeletedEvent, SceneStoryBeatChangedEvent
 
 
 class NovelActsRegistry(EventListener):
 
     def __init__(self):
-        event_dispatcher.register(self, SceneChangedEvent, SceneDeletedEvent, SceneStoryBeatChangedEvent)
         self.novel: Optional[Novel] = None
         self._acts_per_scenes: Dict[Scene, int] = {}
         self._beats: Set[StoryBeat] = set()
@@ -39,6 +38,8 @@ class NovelActsRegistry(EventListener):
 
     def set_novel(self, novel: Novel):
         self.novel = novel
+        dispatcher = event_dispatchers.instance(self.novel)
+        dispatcher.register(self, SceneChangedEvent, SceneDeletedEvent, SceneStoryBeatChangedEvent)
         self.refresh()
 
     @overrides

--- a/src/main/python/plotlyst/service/grammar.py
+++ b/src/main/python/plotlyst/service/grammar.py
@@ -26,8 +26,8 @@ from language_tool_python import LanguageTool
 from overrides import overrides
 
 from src.main.python.plotlyst.core.domain import Novel, Event
-from src.main.python.plotlyst.event.core import emit_event, emit_info, EventListener
-from src.main.python.plotlyst.event.handler import event_dispatcher
+from src.main.python.plotlyst.event.core import emit_global_event, emit_info, EventListener
+from src.main.python.plotlyst.event.handler import global_event_dispatcher
 from src.main.python.plotlyst.events import LanguageToolSet, CharacterChangedEvent
 
 
@@ -57,7 +57,7 @@ class LanguageToolProxy:
         self._language_tool = language_tool
         self._error = None
         emit_info('Grammar checker was set up.')
-        emit_event(LanguageToolSet(self, self._language_tool))
+        emit_global_event(LanguageToolSet(self, self._language_tool))
 
     def set_error(self, error_msg: str):
         self._error = error_msg

--- a/src/main/python/plotlyst/service/grammar.py
+++ b/src/main/python/plotlyst/service/grammar.py
@@ -24,10 +24,9 @@ import language_tool_python
 from PyQt6.QtCore import QRunnable
 from language_tool_python import LanguageTool
 from overrides import overrides
-
 from src.main.python.plotlyst.core.domain import Novel, Event
 from src.main.python.plotlyst.event.core import emit_global_event, emit_info, EventListener
-from src.main.python.plotlyst.event.handler import global_event_dispatcher
+from src.main.python.plotlyst.event.handler import event_dispatchers
 from src.main.python.plotlyst.events import LanguageToolSet, CharacterChangedEvent
 
 
@@ -89,8 +88,6 @@ class Dictionary(EventListener):
     def __init__(self):
         self.novel: Optional[Novel] = None
         self.words: Set[str] = set()
-        event_dispatcher.register(self, CharacterChangedEvent)
-        # event_dispatcher.register(self, LocationChangedEvent)
 
     @overrides
     def event_received(self, event: Event):
@@ -98,6 +95,8 @@ class Dictionary(EventListener):
 
     def set_novel(self, novel: Novel):
         self.novel = novel
+        dispatcher = event_dispatchers.instance(self.novel)
+        dispatcher.register(self, CharacterChangedEvent)
         self.refresh()
 
     def refresh(self):

--- a/src/main/python/plotlyst/service/importer.py
+++ b/src/main/python/plotlyst/service/importer.py
@@ -105,7 +105,7 @@ class ScrivenerSyncImporter(SyncImporter):
 
     @busy
     def sync(self, novel: Novel):
-        emit_event(NovelAboutToSyncEvent(self, novel))
+        emit_event(novel, NovelAboutToSyncEvent(self, novel))
         novel.import_origin.last_mod_time = self._mod_time(novel)
 
         new_novel = self._parser.parse_project(novel.import_origin.source)
@@ -118,7 +118,7 @@ class ScrivenerSyncImporter(SyncImporter):
         self._sync_scenes(novel, new_novel)
 
         self.repo.update_project_novel(novel)
-        emit_event(NovelSyncEvent(self, novel))
+        emit_event(novel, NovelSyncEvent(self, novel))
 
     def _mod_time(self, novel: Novel) -> int:
         scriv_file = self._parser.find_scrivener_file(novel.import_origin.source)
@@ -145,7 +145,7 @@ class ScrivenerSyncImporter(SyncImporter):
                 self.repo.update_character(character)
             else:
                 delete_character(novel, character, forced=True)
-                emit_event(CharacterDeletedEvent(self, character))
+                emit_event(novel, CharacterDeletedEvent(self, character))
 
     def _sync_chapters(self, novel: Novel, new_novel: Novel):
         current: Dict[Chapter, Chapter] = {}
@@ -179,7 +179,7 @@ class ScrivenerSyncImporter(SyncImporter):
                 if new_scene.chapter:
                     old_scene.chapter = chapters[new_scene.chapter]
                 new_scenes.append(old_scene)
-                
+
                 self.repo.update_scene(old_scene)
                 if old_scene.manuscript:
                     self.repo.update_doc(novel, old_scene.manuscript)
@@ -193,6 +193,6 @@ class ScrivenerSyncImporter(SyncImporter):
 
         for scene in removed_scenes:
             delete_scene(novel, scene, forced=True)
-            emit_event(SceneDeletedEvent(self, scene))
+            emit_event(novel, SceneDeletedEvent(self, scene))
 
         novel.scenes[:] = new_scenes

--- a/src/main/python/plotlyst/service/resource.py
+++ b/src/main/python/plotlyst/service/resource.py
@@ -29,7 +29,7 @@ from overrides import overrides
 from pypandoc import download_pandoc
 
 from src.main.python.plotlyst.env import app_env
-from src.main.python.plotlyst.event.core import emit_event
+from src.main.python.plotlyst.event.core import emit_global_event
 from src.main.python.plotlyst.resources import ResourceType, resource_manager, ResourceDownloadedEvent, \
     ResourceRemovedEvent, is_nltk, PANDOC_VERSION
 
@@ -51,7 +51,7 @@ def remove_resource(resource_type: ResourceType):
 
     if os.path.exists(resource_path):
         shutil.rmtree(resource_path)
-    emit_event(ResourceRemovedEvent(resource, resource_type))
+    emit_global_event(ResourceRemovedEvent(resource, resource_type))
 
 
 def download_resource(resource_type: ResourceType):
@@ -99,7 +99,7 @@ class NltkResourceDownloadWorker(QRunnable):
             with zipfile.ZipFile(resource_zip_path) as zip_ref:
                 zip_ref.extractall(resource_path)
 
-            emit_event(ResourceDownloadedEvent(self, resource_type))
+            emit_global_event(ResourceDownloadedEvent(self, resource_type))
             print(f'Resource {resource.name} was successfully downloaded')
 
 
@@ -123,7 +123,7 @@ class JreResourceDownloadWorker(QRunnable):
         with tarfile.open(resource_tar_path) as tar_ref:
             tar_ref.extractall(resource_path)
 
-        emit_event(ResourceDownloadedEvent(self, self._type))
+        emit_global_event(ResourceDownloadedEvent(self, self._type))
 
 
 class PandocResourceDownloadWorker(QRunnable):
@@ -144,4 +144,4 @@ class PandocResourceDownloadWorker(QRunnable):
         os.makedirs(target_path, exist_ok=True)
 
         download_pandoc(version=PANDOC_VERSION, targetfolder=target_path, download_folder=resource_path)
-        emit_event(ResourceDownloadedEvent(self, self._type))
+        emit_global_event(ResourceDownloadedEvent(self, self._type))

--- a/src/main/python/plotlyst/service/tour.py
+++ b/src/main/python/plotlyst/service/tour.py
@@ -24,7 +24,7 @@ from PyQt6.QtCore import QObject
 from PyQt6.QtWidgets import QWidget, QDialog
 from qttour import TourManager, TourSequence, TourStep
 
-from src.main.python.plotlyst.event.core import emit_event
+from src.main.python.plotlyst.event.core import emit_global_event
 from src.main.python.plotlyst.view.widget.tour import Tutorial
 from src.main.python.plotlyst.view.widget.tour.core import COLOR_ON_NAVBAR, tour_events, TourEvent, tour_teardowns
 
@@ -79,11 +79,11 @@ class TourService(QObject):
     def _nextEvent(self):
         event = next(self._events_iter, None)
         if event is not None:
-            emit_event(event)
+            emit_global_event(event)
         else:
             self._manager.finish()
 
     def _tourFinished(self):
         teardown = tour_teardowns.get(self._tutorial)
         if teardown:
-            emit_event(teardown(self))
+            emit_global_event(teardown(self))

--- a/src/main/python/plotlyst/test/conftest.py
+++ b/src/main/python/plotlyst/test/conftest.py
@@ -25,7 +25,7 @@ from src.main.python.plotlyst.core.client import json_client
 from src.main.python.plotlyst.core.domain import Character, Scene, Chapter, \
     Novel, Conflict, ConflictType, Plot, PlotType, ScenePlotReference, SceneType, SceneStructureAgenda
 from src.main.python.plotlyst.env import app_env
-from src.main.python.plotlyst.event.handler import event_dispatcher
+from src.main.python.plotlyst.event.handler import global_event_dispatcher
 from src.main.python.plotlyst.view.main_window import MainWindow
 from src.main.python.plotlyst.view.stylesheet import APP_STYLESHEET
 
@@ -58,7 +58,7 @@ def filled_window(qtbot, test_client):
 
 
 def get_main_window(qtbot):
-    event_dispatcher.clear()
+    global_event_dispatcher.clear()
 
     main_window = MainWindow()
     main_window.setStyleSheet(APP_STYLESHEET)

--- a/src/main/python/plotlyst/view/_view.py
+++ b/src/main/python/plotlyst/view/_view.py
@@ -24,6 +24,7 @@ from PyQt6.QtCore import QObject
 from PyQt6.QtWidgets import QWidget, QButtonGroup
 from overrides import overrides
 from qthandy import busy
+
 from src.main.python.plotlyst.core.domain import Novel
 from src.main.python.plotlyst.event.core import EventListener, Event
 from src.main.python.plotlyst.event.handler import global_event_dispatcher, event_dispatchers
@@ -33,18 +34,18 @@ from src.main.python.plotlyst.service.persistence import RepositoryPersistenceMa
 
 class AbstractView(QObject, EventListener):
 
-    def __init__(self, event_types: Optional[List[Any]] = None):
+    def __init__(self, global_event_types: Optional[List[Any]] = None):
         super().__init__(None)
         self._refresh_on_activation: bool = False
         self.widget = QWidget()
         self.title: Optional[QWidget] = None
         self._navigable_button_group: Optional[QButtonGroup] = None
-        if event_types:
-            self._event_types = event_types
+        if global_event_types:
+            self._global_event_types = global_event_types
         else:
-            self._event_types = []
+            self._global_event_types = []
 
-        for event in self._event_types:
+        for event in self._global_event_types:
             global_event_dispatcher.register(self, event)
 
         self.repo = RepositoryPersistenceManager.instance()
@@ -56,15 +57,10 @@ class AbstractView(QObject, EventListener):
 
     @overrides
     def event_received(self, event: Event):
-        refresh = False
-        for et in self._event_types:
-            if isinstance(event, et):
-                refresh = True
-        if refresh:
-            if self.widget.isVisible():
-                self.refresh()
-            else:
-                self._refresh_on_activation = True
+        if self.widget.isVisible():
+            self.refresh()
+        else:
+            self._refresh_on_activation = True
 
     def activate(self):
         if self._refresh_on_activation:
@@ -100,14 +96,15 @@ class AbstractView(QObject, EventListener):
 
 class AbstractNovelView(AbstractView):
 
-    def __init__(self, novel: Novel, event_types: Optional[List[Any]] = None):
+    def __init__(self, novel: Novel, event_types: Optional[List[Any]] = None,
+                 global_event_types: Optional[List[Any]] = None):
         events = event_types if event_types else []
 
         if CharacterDeletedEvent not in events:
             events.append(CharacterDeletedEvent)
         if NovelSyncEvent not in events:
             events.append(NovelSyncEvent)
-        super().__init__()
+        super().__init__(global_event_types)
 
         self.novel = novel
         self._dispatcher = event_dispatchers.instance(self.novel)

--- a/src/main/python/plotlyst/view/_view.py
+++ b/src/main/python/plotlyst/view/_view.py
@@ -111,7 +111,7 @@ class AbstractNovelView(AbstractView):
 
         self.novel = novel
         self._dispatcher = event_dispatchers.instance(self.novel)
-        self._dispatcher.register(self, events)
+        self._dispatcher.register(self, *events)
 
     @busy
     @abstractmethod

--- a/src/main/python/plotlyst/view/character_editor.py
+++ b/src/main/python/plotlyst/view/character_editor.py
@@ -31,7 +31,7 @@ from src.main.python.plotlyst.core.client import json_client
 from src.main.python.plotlyst.core.domain import Novel, Character, Document, MALE, FEMALE, SelectionItem
 from src.main.python.plotlyst.core.template import protagonist_role
 from src.main.python.plotlyst.event.core import EventListener, Event
-from src.main.python.plotlyst.event.handler import event_dispatcher
+from src.main.python.plotlyst.event.handler import event_dispatchers
 from src.main.python.plotlyst.events import NovelAboutToSyncEvent
 from src.main.python.plotlyst.resources import resource_registry
 from src.main.python.plotlyst.service.persistence import RepositoryPersistenceManager
@@ -185,7 +185,8 @@ class CharacterEditor(QObject, EventListener):
         self.ui.tabAttributes.setCurrentWidget(self.ui.tabBackstory)
 
         self.repo = RepositoryPersistenceManager.instance()
-        event_dispatcher.register(self, NovelAboutToSyncEvent)
+        dispatcher = event_dispatchers.instance(self.novel)
+        dispatcher.register(self, NovelAboutToSyncEvent)
 
     @overrides
     def event_received(self, event: Event):

--- a/src/main/python/plotlyst/view/characters_view.py
+++ b/src/main/python/plotlyst/view/characters_view.py
@@ -151,7 +151,7 @@ class CharactersView(AbstractNovelView):
         self.ui.btnBigFiveComparison.setIcon(IconRegistry.big_five_icon(color_on=PLOTLYST_SECONDARY_COLOR))
 
         self.ui.splitterCompTree.setSizes([150, 500])
-        self._wdgComparison = CharacterComparisonWidget(self.ui.pageComparison)
+        self._wdgComparison = CharacterComparisonWidget(self.novel, self.ui.pageComparison)
         self.ui.scrollAreaComparisonContent.layout().addWidget(self._wdgComparison)
         self._wdgCharactersCompTree = CharactersTreeView(self.novel)
         self.ui.wdgCharactersCompTreeParent.layout().addWidget(self._wdgCharactersCompTree)

--- a/src/main/python/plotlyst/view/characters_view.py
+++ b/src/main/python/plotlyst/view/characters_view.py
@@ -28,12 +28,11 @@ from overrides import overrides
 from qthandy import busy, gc, incr_font, bold, vbox, vspacer
 from qthandy.filter import InstantTooltipEventFilter, OpacityEventFilter
 from qtmenu import MenuWidget
-
 from src.main.python.plotlyst.common import PLOTLYST_SECONDARY_COLOR
 from src.main.python.plotlyst.core.domain import Novel, Character, RelationsNetwork, CharacterNode
 from src.main.python.plotlyst.env import app_env
-from src.main.python.plotlyst.event.core import emit_event, EventListener, Event
-from src.main.python.plotlyst.event.handler import event_dispatcher
+from src.main.python.plotlyst.event.core import EventListener, Event, emit_event
+from src.main.python.plotlyst.event.handler import event_dispatchers
 from src.main.python.plotlyst.events import CharacterChangedEvent, CharacterDeletedEvent, NovelSyncEvent
 from src.main.python.plotlyst.model.characters_model import CharactersTableModel
 from src.main.python.plotlyst.model.common import proxy
@@ -67,9 +66,10 @@ class CharactersTitle(QWidget, Ui_CharactersTitle, EventListener):
 
         self.refresh()
 
-        event_dispatcher.register(self, CharacterChangedEvent)
-        event_dispatcher.register(self, CharacterDeletedEvent)
-        event_dispatcher.register(self, NovelSyncEvent)
+        dispatcher = event_dispatchers.instance(self.novel)
+        dispatcher.register(self, CharacterChangedEvent)
+        dispatcher.register(self, CharacterDeletedEvent)
+        dispatcher.register(self, NovelSyncEvent)
 
     @overrides
     def event_received(self, event: Event):
@@ -304,7 +304,7 @@ class CharactersView(AbstractNovelView):
         self.ui.stackedWidget.setCurrentWidget(self.ui.pageView)
         self.title.setVisible(True)
 
-        emit_event(CharacterChangedEvent(self, character))
+        emit_event(self.novel, CharacterChangedEvent(self, character))
         gc(self.editor.widget)
         gc(self.editor)
         self.editor = None
@@ -329,7 +329,7 @@ class CharactersView(AbstractNovelView):
 
         if character and delete_character(self.novel, character):
             self.ui.wdgCharacterSelector.removeCharacter(character)
-            emit_event(CharacterDeletedEvent(self, character))
+            emit_event(self.novel, CharacterDeletedEvent(self, character))
             self.refresh()
 
     @busy

--- a/src/main/python/plotlyst/view/dialog/home.py
+++ b/src/main/python/plotlyst/view/dialog/home.py
@@ -30,7 +30,7 @@ from src.main.python.plotlyst.core.domain import Novel
 from src.main.python.plotlyst.core.scrivener import ScrivenerParser
 from src.main.python.plotlyst.env import app_env
 from src.main.python.plotlyst.event.core import EventListener, Event
-from src.main.python.plotlyst.event.handler import event_dispatcher
+from src.main.python.plotlyst.event.handler import global_event_dispatcher
 from src.main.python.plotlyst.resources import resource_registry, ResourceType
 from src.main.python.plotlyst.service.tour import TourService
 from src.main.python.plotlyst.view.common import link_buttons_to_pages, link_editor_to_btn, ButtonPressResizeEventFilter
@@ -80,7 +80,7 @@ class StoryCreationDialog(QDialog, Ui_StoryCreationDialog, EventListener):
         self._tour_service: TourService = TourService.instance()
         self._eventTypes = [NewStoryTitleInDialogTourEvent, NewStoryTitleFillInDialogTourEvent,
                             NewStoryDialogOkayButtonTourEvent]
-        event_dispatcher.register(self, *self._eventTypes)
+        global_event_dispatcher.register(self, *self._eventTypes)
 
     def display(self) -> Optional[Novel]:
         self._scrivenerNovel = None
@@ -96,7 +96,7 @@ class StoryCreationDialog(QDialog, Ui_StoryCreationDialog, EventListener):
         return None
 
     def hideEvent(self, event):
-        event_dispatcher.deregister(self, *self._eventTypes)
+        global_event_dispatcher.deregister(self, *self._eventTypes)
         super(StoryCreationDialog, self).hideEvent(event)
 
     def event_received(self, event: Event):

--- a/src/main/python/plotlyst/view/home_view.py
+++ b/src/main/python/plotlyst/view/home_view.py
@@ -30,8 +30,8 @@ from src.main.python.plotlyst.common import NAV_BAR_BUTTON_DEFAULT_COLOR, \
     NAV_BAR_BUTTON_CHECKED_COLOR
 from src.main.python.plotlyst.core.client import client
 from src.main.python.plotlyst.core.domain import NovelDescriptor
-from src.main.python.plotlyst.event.core import emit_event, Event
-from src.main.python.plotlyst.event.handler import event_dispatcher
+from src.main.python.plotlyst.event.core import emit_global_event, Event
+from src.main.python.plotlyst.event.handler import global_event_dispatcher
 from src.main.python.plotlyst.events import NovelDeletedEvent, NovelUpdatedEvent
 from src.main.python.plotlyst.resources import resource_registry
 from src.main.python.plotlyst.service.persistence import flush_or_fail
@@ -172,7 +172,7 @@ class HomeView(AbstractView):
         self._novels = client.novels()
         self.refresh()
 
-        event_dispatcher.register(self, NovelUpdatedEvent)
+        global_event_dispatcher.register(self, NovelUpdatedEvent)
 
     def novels(self) -> List[NovelDescriptor]:
         return self._novels
@@ -260,7 +260,7 @@ class HomeView(AbstractView):
             self._selected_novel.title = title
             self._shelvesTreeView.updateNovel(self._selected_novel)
             self.repo.update_project_novel(self._selected_novel)
-            emit_event(NovelUpdatedEvent(self, self._selected_novel))
+            emit_global_event(NovelUpdatedEvent(self, self._selected_novel))
 
     def _subtitle_edited(self, subtitle: str):
         self._selected_novel.subtitle = subtitle
@@ -287,7 +287,7 @@ class HomeView(AbstractView):
         if ask_confirmation(f'Are you sure you want to delete the novel "{novel.title}"?'):
             self.repo.delete_novel(novel)
             self._novels.remove(novel)
-            emit_event(NovelDeletedEvent(self, novel))
+            emit_global_event(NovelDeletedEvent(self, novel))
             if self._selected_novel and novel.id == self._selected_novel.id:
                 self._selected_novel = None
                 self.reset()

--- a/src/main/python/plotlyst/view/manuscript_view.py
+++ b/src/main/python/plotlyst/view/manuscript_view.py
@@ -285,7 +285,7 @@ class ManuscriptView(AbstractNovelView):
         self.notesEditor.setScene(scene)
         self.ui.btnNotes.setEnabled(True)
         self.ui.btnStage.setEnabled(True)
-        self.ui.btnStage.setScene(scene)
+        self.ui.btnStage.setScene(scene, self.novel)
 
         self._recheckDocument()
 

--- a/src/main/python/plotlyst/view/manuscript_view.py
+++ b/src/main/python/plotlyst/view/manuscript_view.py
@@ -30,7 +30,7 @@ from qttextedit.ops import TextEditorSettingsWidget, TextEditorSettingsSection
 from src.main.python.plotlyst.common import PLOTLYST_MAIN_COLOR, RELAXED_WHITE_COLOR
 from src.main.python.plotlyst.core.domain import Novel, Document, Chapter
 from src.main.python.plotlyst.core.domain import Scene
-from src.main.python.plotlyst.event.core import emit_event, emit_critical, emit_info, Event
+from src.main.python.plotlyst.event.core import emit_global_event, emit_critical, emit_info, Event, emit_event
 from src.main.python.plotlyst.events import NovelUpdatedEvent, SceneChangedEvent, OpenDistractionFreeMode, \
     ChapterChangedEvent, SceneDeletedEvent, ExitDistractionFreeMode, NovelSyncEvent, CloseNovelEvent
 from src.main.python.plotlyst.resources import ResourceType
@@ -224,7 +224,7 @@ class ManuscriptView(AbstractNovelView):
         self.ui.treeChapters.refresh()
 
     def _enter_distraction_free(self):
-        emit_event(OpenDistractionFreeMode(self))
+        emit_global_event(OpenDistractionFreeMode(self))
         self.ui.stackedWidget.setCurrentWidget(self.ui.pageDistractionFree)
         margins(self.widget, 0, 0, 0, 0)
         self.ui.wdgTitle.setHidden(True)
@@ -233,7 +233,7 @@ class ManuscriptView(AbstractNovelView):
         self._dist_free_editor.setWordDisplay(self.ui.lblWordCount)
 
     def _exit_distraction_free(self):
-        emit_event(ExitDistractionFreeMode(self))
+        emit_global_event(ExitDistractionFreeMode(self))
         self._dist_free_editor.deactivate()
         margins(self.widget, 4, 2, 2, 2)
         self.ui.stackedWidget.setCurrentWidget(self.ui.pageText)
@@ -344,7 +344,7 @@ class ManuscriptView(AbstractNovelView):
 
     def _scene_title_changed(self, scene: Scene):
         self.repo.update_scene(scene)
-        emit_event(SceneChangedEvent(self, scene))
+        emit_event(self.novel, SceneChangedEvent(self, scene))
 
     def _edit_wc_goal(self):
         goal, changed = QInputDialog.getInt(self.ui.btnEditGoal, 'Word count goal', 'Edit word count target',
@@ -418,7 +418,7 @@ class ManuscriptView(AbstractNovelView):
         self.novel.lang_settings.lang = lang
         self.repo.update_project_novel(self.novel)
         flush_or_fail()
-        emit_event(CloseNovelEvent(self, self.novel))
+        emit_global_event(CloseNovelEvent(self, self.novel))
 
     def _is_empty_page(self) -> bool:
         return self.ui.stackedWidget.currentWidget() == self.ui.pageEmpty

--- a/src/main/python/plotlyst/view/novel_view.py
+++ b/src/main/python/plotlyst/view/novel_view.py
@@ -45,7 +45,7 @@ from src.main.python.plotlyst.view.widget.plot import PlotEditor
 class NovelView(AbstractNovelView):
 
     def __init__(self, novel: Novel):
-        super().__init__(novel, [NovelUpdatedEvent, SceneChangedEvent])
+        super().__init__(novel, [SceneChangedEvent], global_event_types=[NovelUpdatedEvent])
         self.ui = Ui_NovelView()
         self.ui.setupUi(self.widget)
 

--- a/src/main/python/plotlyst/view/novel_view.py
+++ b/src/main/python/plotlyst/view/novel_view.py
@@ -27,7 +27,7 @@ from qthandy.filter import OpacityEventFilter
 from src.main.python.plotlyst.common import PLOTLYST_MAIN_COLOR
 from src.main.python.plotlyst.core.client import json_client
 from src.main.python.plotlyst.core.domain import Novel, Document
-from src.main.python.plotlyst.event.core import emit_event
+from src.main.python.plotlyst.event.core import emit_global_event
 from src.main.python.plotlyst.events import NovelUpdatedEvent, \
     SceneChangedEvent
 from src.main.python.plotlyst.resources import resource_registry
@@ -148,7 +148,7 @@ class NovelView(AbstractNovelView):
             self.novel.title = title
             self.repo.update_project_novel(self.novel)
             self.ui.lblTitle.setText(self.novel.title)
-            emit_event(NovelUpdatedEvent(self, self.novel))
+            emit_global_event(NovelUpdatedEvent(self, self.novel))
 
     def _premise_changed(self):
         text = self.ui.textPremise.textEdit.toPlainText()

--- a/src/main/python/plotlyst/view/reports_view.py
+++ b/src/main/python/plotlyst/view/reports_view.py
@@ -30,7 +30,7 @@ from qthandy.filter import OpacityEventFilter
 from src.main.python.plotlyst.common import PLOTLYST_SECONDARY_COLOR
 from src.main.python.plotlyst.core.domain import Novel
 from src.main.python.plotlyst.event.core import EventListener, Event
-from src.main.python.plotlyst.event.handler import event_dispatcher
+from src.main.python.plotlyst.event.handler import event_dispatchers
 from src.main.python.plotlyst.events import CharacterChangedEvent, SceneChangedEvent, SceneDeletedEvent, \
     PlotCreatedEvent, CharacterDeletedEvent, NovelSyncEvent
 from src.main.python.plotlyst.view._view import AbstractNovelView
@@ -68,7 +68,8 @@ class ReportPage(QWidget, EventListener):
         vbox(self._wdgCenter)
         self._wdgCenter.setProperty('white-bg', True)
 
-        event_dispatcher.register(self, NovelSyncEvent)
+        self._dispatcher = event_dispatchers.instance(self._novel)
+        self._dispatcher.register(self, NovelSyncEvent)
 
     @overrides
     def showEvent(self, event: QShowEvent) -> None:
@@ -98,8 +99,7 @@ class CharactersReportPage(ReportPage):
 
     def __init__(self, novel: Novel, parent=None):
         super(CharactersReportPage, self).__init__(novel, parent)
-        event_dispatcher.register(self, CharacterChangedEvent)
-        event_dispatcher.register(self, CharacterDeletedEvent)
+        self._dispatcher.register(self, CharacterChangedEvent, CharacterDeletedEvent)
 
     @overrides
     def _initReport(self):
@@ -109,10 +109,8 @@ class CharactersReportPage(ReportPage):
 class ScenesReportPage(ReportPage):
     def __init__(self, novel: Novel, parent=None):
         super(ScenesReportPage, self).__init__(novel, parent)
-        event_dispatcher.register(self, SceneChangedEvent)
-        event_dispatcher.register(self, SceneDeletedEvent)
-        event_dispatcher.register(self, CharacterChangedEvent)
-        event_dispatcher.register(self, CharacterDeletedEvent)
+        self._dispatcher.register(self, SceneChangedEvent, SceneDeletedEvent, CharacterChangedEvent,
+                                  CharacterDeletedEvent)
 
     @overrides
     def _initReport(self):
@@ -122,10 +120,8 @@ class ScenesReportPage(ReportPage):
 class ConflictsReportPage(ReportPage):
     def __init__(self, novel: Novel, parent=None):
         super(ConflictsReportPage, self).__init__(novel, parent)
-        event_dispatcher.register(self, SceneChangedEvent)
-        event_dispatcher.register(self, SceneDeletedEvent)
-        event_dispatcher.register(self, CharacterChangedEvent)
-        event_dispatcher.register(self, CharacterDeletedEvent)
+        self._dispatcher.register(self, SceneChangedEvent, SceneDeletedEvent, CharacterChangedEvent,
+                                  CharacterDeletedEvent)
 
     @overrides
     def _initReport(self):
@@ -144,8 +140,7 @@ class ArcReportPage(ReportPage):
 class ManuscriptReportPage(ReportPage):
     def __init__(self, novel: Novel, parent=None):
         super(ManuscriptReportPage, self).__init__(novel, parent)
-        event_dispatcher.register(self, SceneChangedEvent)
-        event_dispatcher.register(self, SceneDeletedEvent)
+        self._dispatcher.register(self, SceneChangedEvent, SceneDeletedEvent)
         self._wc_cache: List[int] = []
 
     @overrides

--- a/src/main/python/plotlyst/view/scene_editor.py
+++ b/src/main/python/plotlyst/view/scene_editor.py
@@ -33,7 +33,7 @@ from src.main.python.plotlyst.core.domain import Novel, Scene, Document, StoryBe
     Character, ScenePlotReference, TagReference
 from src.main.python.plotlyst.env import app_env
 from src.main.python.plotlyst.event.core import emit_info, EventListener, Event, emit_event
-from src.main.python.plotlyst.event.handler import event_dispatcher
+from src.main.python.plotlyst.event.handler import event_dispatchers
 from src.main.python.plotlyst.events import NovelAboutToSyncEvent, SceneStoryBeatChangedEvent
 from src.main.python.plotlyst.model.characters_model import CharactersSceneAssociationTableModel
 from src.main.python.plotlyst.service.cache import acts_registry
@@ -138,7 +138,8 @@ class SceneEditor(QObject, EventListener):
         self.repo = RepositoryPersistenceManager.instance()
         self.ui.btnAttributes.setChecked(True)
 
-        event_dispatcher.register(self, NovelAboutToSyncEvent)
+        dispatcher = event_dispatchers.instance(self.novel)
+        dispatcher.register(self, NovelAboutToSyncEvent)
 
     @overrides
     def event_received(self, event: Event):
@@ -208,7 +209,7 @@ class SceneEditor(QObject, EventListener):
         self.scene.link_beat(self.novel.active_story_structure, beat)
         self.ui.wdgStructure.highlightScene(self.scene)
 
-        emit_event(SceneStoryBeatChangedEvent(self, self.scene))
+        emit_event(self.novel, SceneStoryBeatChangedEvent(self, self.scene))
 
     def _beat_removed(self, beat: StoryBeat):
         scene = acts_registry.scene(beat)
@@ -223,7 +224,7 @@ class SceneEditor(QObject, EventListener):
         else:
             self.repo.update_scene(scene)
 
-        emit_event(SceneStoryBeatChangedEvent(self, scene))
+        emit_event(self.novel, SceneStoryBeatChangedEvent(self, scene))
 
     def _update_notes(self):
         if self.scene.document:

--- a/src/main/python/plotlyst/view/widget/cards.py
+++ b/src/main/python/plotlyst/view/widget/cards.py
@@ -213,7 +213,7 @@ class SceneCard(Ui_SceneCard, Card):
         else:
             self.lblType.clear()
 
-        self.btnStage.setScene(self.scene)
+        self.btnStage.setScene(self.scene, self.novel)
 
         self._setStyleSheet()
 

--- a/src/main/python/plotlyst/view/widget/character/comp.py
+++ b/src/main/python/plotlyst/view/widget/character/comp.py
@@ -31,8 +31,8 @@ from qthandy import vbox, hbox, line, flow, gc, vspacer, clear_layout, bold, mar
 from src.main.python.plotlyst.core.domain import Character, Novel, TemplateValue
 from src.main.python.plotlyst.core.template import iq_field, eq_field, rationalism_field, creativity_field, \
     willpower_field, TemplateField
-from src.main.python.plotlyst.event.core import emit_event, EventListener, Event
-from src.main.python.plotlyst.event.handler import event_dispatcher
+from src.main.python.plotlyst.event.core import EventListener, Event, emit_event
+from src.main.python.plotlyst.event.handler import event_dispatchers
 from src.main.python.plotlyst.events import CharacterSummaryChangedEvent, CharacterChangedEvent, CharacterDeletedEvent
 from src.main.python.plotlyst.service.persistence import RepositoryPersistenceManager
 from src.main.python.plotlyst.view.common import fade_out_and_gc
@@ -106,7 +106,7 @@ class SummaryDisplay(QTextEdit, BaseDisplay):
 
         self._character.set_summary(self.toPlainText())
         self.repo.update_character(self._character)
-        emit_event(CharacterSummaryChangedEvent(self, self._character))
+        emit_event(self._character.novel, CharacterSummaryChangedEvent(self, self._character))
 
 
 class FacultiesDisplay(QWidget, BaseDisplay):
@@ -203,7 +203,9 @@ class CharacterOverviewWidget(QWidget, EventListener):
 
         self.layout().addWidget(self._displayContainer)
         self.layout().addWidget(vspacer())
-        event_dispatcher.register(self, CharacterChangedEvent)
+
+        dispatcher = event_dispatchers.instance(self._character.novel)
+        dispatcher.register(self, CharacterChangedEvent)
 
     @overrides
     def event_received(self, event: Event):
@@ -326,7 +328,8 @@ class CharactersTreeView(TreeView, EventListener):
         margins(self._centralWidget, top=20)
         self.refresh()
 
-        event_dispatcher.register(self, CharacterDeletedEvent)
+        dispatcher = event_dispatchers.instance(self._novel)
+        dispatcher.register(self, CharacterDeletedEvent)
 
     @overrides
     def event_received(self, event: Event):

--- a/src/main/python/plotlyst/view/widget/characters.py
+++ b/src/main/python/plotlyst/view/widget/characters.py
@@ -48,7 +48,7 @@ from src.main.python.plotlyst.core.template import secondary_role, guide_role, l
     promote_role, demote_role
 from src.main.python.plotlyst.env import app_env
 from src.main.python.plotlyst.event.core import emit_critical, EventListener, Event
-from src.main.python.plotlyst.event.handler import event_dispatcher
+from src.main.python.plotlyst.event.handler import event_dispatchers
 from src.main.python.plotlyst.events import CharacterSummaryChangedEvent
 from src.main.python.plotlyst.model.common import DistributionFilterProxyModel
 from src.main.python.plotlyst.model.distribution import CharactersScenesDistributionTableModel, \
@@ -1311,10 +1311,10 @@ class CharactersProgressWidget(QWidget, Ui_CharactersProgressWidget, EventListen
         self._chartSecondary.refresh()
         self._chartMinor.refresh()
 
-        event_dispatcher.register(self, CharacterSummaryChangedEvent)
-
     def setNovel(self, novel: Novel):
         self.novel = novel
+        dispatcher = event_dispatchers.instance(self.novel)
+        dispatcher.register(self, CharacterSummaryChangedEvent)
 
     @overrides
     def event_received(self, event: Event):

--- a/src/main/python/plotlyst/view/widget/input.py
+++ b/src/main/python/plotlyst/view/widget/input.py
@@ -38,7 +38,7 @@ from src.main.python.plotlyst.core.domain import TextStatistics, Character
 from src.main.python.plotlyst.core.text import wc
 from src.main.python.plotlyst.env import app_env
 from src.main.python.plotlyst.event.core import EventListener, Event
-from src.main.python.plotlyst.event.handler import event_dispatcher
+from src.main.python.plotlyst.event.handler import global_event_dispatcher
 from src.main.python.plotlyst.events import LanguageToolSet
 from src.main.python.plotlyst.model.characters_model import CharactersTableModel
 from src.main.python.plotlyst.model.common import proxy
@@ -178,7 +178,7 @@ class GrammarHighlighter(AbstractTextBlockHighlighter, EventListener):
         self._asyncTimer.setInterval(20)
         self._asyncTimer.timeout.connect(self._highlightNextBlock)
 
-        event_dispatcher.register(self, LanguageToolSet)
+        global_event_dispatcher.register(self, LanguageToolSet)
 
     def checkEnabled(self) -> bool:
         return self._checkEnabled

--- a/src/main/python/plotlyst/view/widget/plot.py
+++ b/src/main/python/plotlyst/view/widget/plot.py
@@ -40,7 +40,7 @@ from src.main.python.plotlyst.core.template import antagonist_role
 from src.main.python.plotlyst.core.text import html
 from src.main.python.plotlyst.env import app_env
 from src.main.python.plotlyst.event.core import EventListener, Event
-from src.main.python.plotlyst.event.handler import event_dispatcher
+from src.main.python.plotlyst.event.handler import event_dispatchers
 from src.main.python.plotlyst.events import CharacterChangedEvent, CharacterDeletedEvent
 from src.main.python.plotlyst.service.persistence import RepositoryPersistenceManager, delete_plot
 from src.main.python.plotlyst.settings import STORY_LINE_COLOR_CODES
@@ -574,8 +574,8 @@ class PlotWidget(QFrame, Ui_PlotWidget, EventListener):
 
         self.repo = RepositoryPersistenceManager.instance()
 
-        event_dispatcher.register(self, CharacterChangedEvent)
-        event_dispatcher.register(self, CharacterDeletedEvent)
+        dispatcher = event_dispatchers.instance(self.novel)
+        dispatcher.register(self, CharacterChangedEvent, CharacterDeletedEvent)
 
     @overrides
     def event_received(self, event: Event):

--- a/src/main/python/plotlyst/view/widget/progress.py
+++ b/src/main/python/plotlyst/view/widget/progress.py
@@ -32,7 +32,7 @@ from src.main.python.plotlyst.common import CHARACTER_MAJOR_COLOR, CHARACTER_SEC
 from src.main.python.plotlyst.core.domain import Novel, SceneStage
 from src.main.python.plotlyst.core.template import RoleImportance
 from src.main.python.plotlyst.event.core import EventListener, Event
-from src.main.python.plotlyst.event.handler import event_dispatcher
+from src.main.python.plotlyst.event.handler import event_dispatchers
 from src.main.python.plotlyst.events import SceneStatusChangedEvent
 from src.main.python.plotlyst.service.cache import acts_registry
 from src.main.python.plotlyst.view.common import icon_to_html_img
@@ -74,7 +74,8 @@ class SceneStageProgressCharts(EventListener):
 
         self._act_colors = {1: ACT_ONE_COLOR, 2: ACT_TWO_COLOR, 3: ACT_THREE_COLOR}
 
-        event_dispatcher.register(self, SceneStatusChangedEvent)
+        dispatcher = event_dispatchers.instance(self.novel)
+        dispatcher.register(self, SceneStatusChangedEvent)
 
     @overrides
     def event_received(self, event: Event):

--- a/src/main/python/plotlyst/view/widget/scene/editor.py
+++ b/src/main/python/plotlyst/view/widget/scene/editor.py
@@ -27,8 +27,8 @@ from qthandy import vbox, vspacer, transparent, sp, line, incr_font
 from qtmenu import MenuWidget
 
 from src.main.python.plotlyst.core.domain import Scene, Novel
-from src.main.python.plotlyst.event.core import emit_event, EventListener, Event
-from src.main.python.plotlyst.event.handler import event_dispatcher
+from src.main.python.plotlyst.event.core import EventListener, Event, emit_event
+from src.main.python.plotlyst.event.handler import event_dispatchers
 from src.main.python.plotlyst.events import SceneChangedEvent
 from src.main.python.plotlyst.service.persistence import RepositoryPersistenceManager
 from src.main.python.plotlyst.view.common import DelayedSignalSlotConnector, action
@@ -67,7 +67,8 @@ class SceneMiniEditor(QWidget, EventListener):
         DelayedSignalSlotConnector(self._textSynopsis.textChanged, self._save, parent=self)
 
         self._repo = RepositoryPersistenceManager.instance()
-        event_dispatcher.register(self, SceneChangedEvent)
+        dispatcher = event_dispatchers.instance(self._novel)
+        dispatcher.register(self, SceneChangedEvent)
 
     def setScene(self, scene: Scene):
         self.setScenes([scene])
@@ -116,4 +117,4 @@ class SceneMiniEditor(QWidget, EventListener):
         if self._currentScene and self._currentScene.synopsis != self._textSynopsis.toPlainText():
             self._currentScene.synopsis = self._textSynopsis.toPlainText()
             self._repo.update_scene(self._currentScene)
-            emit_event(SceneChangedEvent(self, self._currentScene))
+            emit_event(self._novel, SceneChangedEvent(self, self._currentScene))

--- a/src/main/python/plotlyst/view/widget/scene/tree.py
+++ b/src/main/python/plotlyst/view/widget/scene/tree.py
@@ -248,7 +248,7 @@ class ScenesTreeView(TreeView, EventListener):
         wdg = self.__initSceneWidget(scene)
         insert_before_the_end(self._centralWidget, wdg)
 
-        self.repo.update_novel(self._novel)
+        self.repo.insert_scene(self._novel, scene)
         emit_event(self._novel, SceneChangedEvent(self, scene))
         self.sceneAdded.emit(scene)
 
@@ -294,6 +294,7 @@ class ScenesTreeView(TreeView, EventListener):
         scene = self._novel.new_scene()
         scene.chapter = chapterWdg.chapter()
         self._novel.scenes.append(scene)
+
         self.repo.insert_scene(self._novel, scene)
         sceneWdg = self.__initSceneWidget(scene)
         chapterWdg.addChild(sceneWdg)

--- a/src/main/python/plotlyst/view/widget/utility.py
+++ b/src/main/python/plotlyst/view/widget/utility.py
@@ -30,7 +30,7 @@ from qthandy.filter import OpacityEventFilter
 
 from src.main.python.plotlyst.common import PLOTLYST_MAIN_COMPLEMENTARY_COLOR
 from src.main.python.plotlyst.event.core import EventListener, Event
-from src.main.python.plotlyst.event.handler import event_dispatcher
+from src.main.python.plotlyst.event.handler import global_event_dispatcher
 from src.main.python.plotlyst.model.common import proxy
 from src.main.python.plotlyst.resources import ResourceType, resource_manager, ResourceDescriptor, \
     ResourceStatusChangedEvent
@@ -391,7 +391,7 @@ class ResourceManagerWidget(QWidget, EventListener):
             self._gridLayout.addWidget(contr.btnDownload, i + 2, 3, alignment=Qt.AlignmentFlag.AlignCenter)
             self._gridLayout.addWidget(spacer(), i + 2, 4)
 
-        event_dispatcher.register(self, ResourceStatusChangedEvent)
+        global_event_dispatcher.register(self, ResourceStatusChangedEvent)
 
     @overrides
     def event_received(self, event: Event):


### PR DESCRIPTION
- [x] update event received in _view
- [x] separate novel and global events in _view

test:
- [x] novel rename, update in home
- [x] tour
- [x] tour exit, new novel manuscript scene update
- [x] delete novel from home
- [x] char name change in dictionary
- [x] char title on char change
- [x] char summary update
- [x] char change for plot
- [x] scenes title