### PR TITLE
Persist diagrams

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10.12
+          python-version: 3.10.13
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.5.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.10.12
+          python-version: 3.10.13
       - name: Prepare GUI tests
         run: |
           sudo apt install libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils

--- a/src/main/python/plotlyst/core/client.py
+++ b/src/main/python/plotlyst/core/client.py
@@ -409,7 +409,10 @@ class JsonClient:
             return
 
         json_str = self.__load_diagram(novel, diagram.id)
-        diagram.data = DiagramData.from_json(json_str)
+        if json_str:
+            diagram.data = DiagramData.from_json(json_str)
+        else:
+            diagram.data = DiagramData()
         diagram.loaded = True
 
     def update_document(self, novel: Novel, document: Document):
@@ -547,7 +550,8 @@ class JsonClient:
                       story_structures=novel_info.story_structures, character_profiles=novel_info.character_profiles,
                       conflicts=conflicts, goals=[x for x in novel_info.goals if str(x.id) in goal_ids], tags=tags_dict,
                       documents=novel_info.documents, premise=novel_info.premise, synopsis=novel_info.synopsis,
-                      prefs=novel_info.prefs, manuscript_goals=novel_info.manuscript_goals, events_map=novel_info.events_map,
+                      prefs=novel_info.prefs, manuscript_goals=novel_info.manuscript_goals,
+                      events_map=novel_info.events_map,
                       character_networks=novel_info.character_networks)
 
         world_path = self.novels_dir.joinpath(str(novel_info.id)).joinpath('world.json')

--- a/src/main/python/plotlyst/core/client.py
+++ b/src/main/python/plotlyst/core/client.py
@@ -43,7 +43,8 @@ from src.main.python.plotlyst.core.domain import Novel, Character, Scene, Chapte
     three_act_structure, SceneStoryBeat, Tag, default_general_tags, TagType, \
     default_tag_types, LanguageSettings, ImportOrigin, NovelPreferences, Goal, CharacterPreferences, TagReference, \
     ScenePlotReferenceData, MiceQuotient, SceneDrive, WorldBuilding, Board, \
-    default_big_five_values, CharacterPlan, ManuscriptGoals
+    default_big_five_values, CharacterPlan, ManuscriptGoals, Diagram, DiagramData, default_events_map, \
+    default_character_networks
 from src.main.python.plotlyst.core.template import Role, exclude_if_empty, exclude_if_black
 from src.main.python.plotlyst.env import app_env
 
@@ -200,6 +201,8 @@ class NovelInfo:
     world: WorldBuilding = field(default_factory=WorldBuilding)
     board: Board = field(default_factory=Board)
     manuscript_goals: ManuscriptGoals = field(default_factory=ManuscriptGoals)
+    events_map: Diagram = field(default_factory=default_events_map)
+    character_networks: List[Diagram] = field(default_factory=default_character_networks)
 
 
 @dataclass
@@ -286,6 +289,12 @@ class JsonClient:
         if not scenes_dir_.exists():
             scenes_dir_.mkdir()
         return scenes_dir_
+
+    def diagrams_dir(self, novel: Novel):
+        diagrams_dir_ = self.novels_dir.joinpath(str(novel.id)).joinpath('diagrams')
+        if not diagrams_dir_.exists():
+            diagrams_dir_.mkdir()
+        return diagrams_dir_
 
     def docs_dir(self, novel: Novel) -> Path:
         docs_dir_ = self.novels_dir.joinpath(str(novel.id)).joinpath('docs')
@@ -395,11 +404,22 @@ class JsonClient:
             if scene.manuscript and not scene.manuscript.loaded:
                 self.load_document(novel, scene.manuscript)
 
-    def save_document(self, novel: Novel, document: Document):
+    def load_diagram(self, novel: Novel, diagram: Diagram):
+        if diagram.loaded:
+            return
+
+        json_str = self.__load_diagram(novel, diagram.id)
+        diagram.data = DiagramData.from_json(json_str)
+        diagram.loaded = True
+
+    def update_document(self, novel: Novel, document: Document):
         self.__persist_doc(novel, document)
 
     def delete_document(self, novel: Novel, document: Document):
         self.__delete_doc(novel, document)
+
+    def update_diagram(self, novel: Novel, diagram: Diagram):
+        self._persist_diagram(novel, diagram)
 
     def fetch_novel(self, id: uuid.UUID) -> Novel:
         project_novel_info: ProjectNovelInfo = self._find_project_novel_info_or_fail(id)
@@ -527,7 +547,8 @@ class JsonClient:
                       story_structures=novel_info.story_structures, character_profiles=novel_info.character_profiles,
                       conflicts=conflicts, goals=[x for x in novel_info.goals if str(x.id) in goal_ids], tags=tags_dict,
                       documents=novel_info.documents, premise=novel_info.premise, synopsis=novel_info.synopsis,
-                      prefs=novel_info.prefs, manuscript_goals=novel_info.manuscript_goals)
+                      prefs=novel_info.prefs, manuscript_goals=novel_info.manuscript_goals, events_map=novel_info.events_map,
+                      character_networks=novel_info.character_networks)
 
         world_path = self.novels_dir.joinpath(str(novel_info.id)).joinpath('world.json')
         if os.path.exists(world_path):
@@ -565,7 +586,8 @@ class JsonClient:
                                tag_types=list(novel.tags.keys()),
                                documents=novel.documents,
                                premise=novel.premise, synopsis=novel.synopsis,
-                               version=LATEST_VERSION, prefs=novel.prefs, manuscript_goals=novel.manuscript_goals)
+                               version=LATEST_VERSION, prefs=novel.prefs, manuscript_goals=novel.manuscript_goals,
+                               events_map=novel.events_map, character_networks=novel.character_networks)
 
         self.__persist_info(self.novels_dir, novel_info)
         self._persist_world(novel.id, novel.world)
@@ -609,6 +631,12 @@ class JsonClient:
                          drive=scene.drive)
         self.__persist_info(self.scenes_dir(novel), info)
 
+    def _persist_diagram(self, novel: Novel, diagram: Diagram):
+        diagrams_dir = self.diagrams_dir(novel)
+        if not os.path.exists(str(diagrams_dir)):
+            os.mkdir(diagrams_dir)
+        self.__persist_info(diagrams_dir, diagram.data)
+
     @staticmethod
     def __id_or_none(item):
         return item.id if item else None
@@ -646,6 +674,14 @@ class JsonClient:
             return ''
         novel_doc_dir = self.docs_dir(novel).joinpath(str(novel.id))
         path = novel_doc_dir.joinpath(self.__json_file(data_uuid))
+        if not os.path.exists(path):
+            return ''
+        with open(path, encoding='utf8') as json_file:
+            return json_file.read()
+
+    def __load_diagram(self, novel: Novel, diagram_uuid: uuid.UUID) -> str:
+        diagrams_dir = self.diagrams_dir(novel)
+        path = diagrams_dir.joinpath(self.__json_file(diagram_uuid))
         if not os.path.exists(path):
             return ''
         with open(path, encoding='utf8') as json_file:

--- a/src/main/python/plotlyst/core/client.py
+++ b/src/main/python/plotlyst/core/client.py
@@ -639,7 +639,7 @@ class JsonClient:
         diagrams_dir = self.diagrams_dir(novel)
         if not os.path.exists(str(diagrams_dir)):
             os.mkdir(diagrams_dir)
-        self.__persist_info(diagrams_dir, diagram.data)
+        self.__persist_json_by_id(diagrams_dir, diagram.data.to_json(), diagram.id)
 
     @staticmethod
     def __id_or_none(item):

--- a/src/main/python/plotlyst/core/domain.py
+++ b/src/main/python/plotlyst/core/domain.py
@@ -26,6 +26,7 @@ from datetime import datetime
 from enum import Enum
 from typing import List, Optional, Any, Dict
 
+from PyQt6.QtCore import Qt
 from dataclasses_json import dataclass_json, Undefined, config
 from overrides import overrides
 
@@ -1749,10 +1750,25 @@ class Node(CharacterBased):
         self._character: Optional[Character] = None
 
 
+@dataclass
+class Connector:
+    source_id: uuid.UUID
+    target_id: uuid.UUID
+    source_angle: float
+    target_angle: float
+    type: str = ''
+    pen: Qt.PenStyle = Qt.PenStyle.SolidLine
+    width: int = 1
+    icon: str = field(default='', metadata=config(exclude=exclude_if_empty))
+    color: str = field(default='black', metadata=config(exclude=exclude_if_black))
+    text: str = field(default='', metadata=config(exclude=exclude_if_empty))
+
+
 @dataclass_json(undefined=Undefined.EXCLUDE)
 @dataclass
 class DiagramData:
     nodes: List[Node] = field(default_factory=list)
+    connectors: List[Connector] = field(default_factory=list)
 
 
 @dataclass

--- a/src/main/python/plotlyst/core/domain.py
+++ b/src/main/python/plotlyst/core/domain.py
@@ -1715,10 +1715,30 @@ def default_tags() -> Dict[TagType, List[Tag]]:
     return tags
 
 
+class DiagramNodeType(Enum):
+    CHARACTER = 'character'
+    STICKER = 'sticker'
+    EVENT = 'event'
+    COMMENT = 'comment'
+    SETUP = 'setup'
+
+
+NODE_SUBTYPE_GOAL = 'goal'
+NODE_SUBTYPE_CONFLICT = 'conflict'
+NODE_SUBTYPE_DISTURBANCE = 'disturbance'
+NODE_SUBTYPE_BACKSTORY = 'backstory'
+NODE_SUBTYPE_QUESTION = 'question'
+NODE_SUBTYPE_FORESHADOWING = 'foreshadowing'
+NODE_SUBTYPE_TOOL = 'tool'
+NODE_SUBTYPE_COST = 'cost'
+
+
 @dataclass
 class Node(CharacterBased):
     x: float
     y: float
+    type: DiagramNodeType
+    subtype: str = field(default='', metadata=config(exclude=exclude_if_empty))
     id: uuid.UUID = field(default_factory=uuid.uuid4)
     character_id: Optional[uuid.UUID] = field(default=None, metadata=config(exclude=exclude_if_empty))
     icon: str = field(default='', metadata=config(exclude=exclude_if_empty))

--- a/src/main/python/plotlyst/core/domain.py
+++ b/src/main/python/plotlyst/core/domain.py
@@ -1716,15 +1716,17 @@ def default_tags() -> Dict[TagType, List[Tag]]:
 
 
 @dataclass
-class Node:
+class Node(CharacterBased):
     x: float
     y: float
-
-
-@dataclass
-class CharacterNode(Node, CharacterBased):
     id: uuid.UUID = field(default_factory=uuid.uuid4)
-    character_id: Optional[uuid.UUID] = None
+    character_id: Optional[uuid.UUID] = field(default=None, metadata=config(exclude=exclude_if_empty))
+    icon: str = field(default='', metadata=config(exclude=exclude_if_empty))
+    color: str = field(default='black', metadata=config(exclude=exclude_if_black))
+    text: str = field(default='', metadata=config(exclude=exclude_if_empty))
+
+    def __post_init__(self):
+        self._character: Optional[Character] = None
 
 
 @dataclass_json(undefined=Undefined.EXCLUDE)

--- a/src/main/python/plotlyst/core/domain.py
+++ b/src/main/python/plotlyst/core/domain.py
@@ -1728,12 +1728,12 @@ class CharacterNode(Node, CharacterBased):
 
 
 @dataclass
-class RelationsNetwork:
+class Diagram:
     title: str
     id: uuid.UUID = field(default_factory=uuid.uuid4)
     icon: str = field(default='', metadata=config(exclude=exclude_if_empty))
     icon_color: str = field(default='black', metadata=config(exclude=exclude_if_black))
-    nodes: List[CharacterNode] = field(default_factory=list)
+    nodes: List[Node] = field(default_factory=list)
 
 
 @dataclass

--- a/src/main/python/plotlyst/core/domain.py
+++ b/src/main/python/plotlyst/core/domain.py
@@ -1727,13 +1727,40 @@ class CharacterNode(Node, CharacterBased):
     character_id: Optional[uuid.UUID] = None
 
 
+@dataclass_json(undefined=Undefined.EXCLUDE)
+@dataclass
+class DiagramData:
+    nodes: List[Node] = field(default_factory=list)
+
+
 @dataclass
 class Diagram:
     title: str
     id: uuid.UUID = field(default_factory=uuid.uuid4)
     icon: str = field(default='', metadata=config(exclude=exclude_if_empty))
     icon_color: str = field(default='black', metadata=config(exclude=exclude_if_black))
-    nodes: List[Node] = field(default_factory=list)
+
+    def __post_init__(self):
+        self.loaded: bool = False
+        self.data: Optional[DiagramData] = None
+
+    @overrides
+    def __eq__(self, other: 'Diagram'):
+        if isinstance(other, Diagram):
+            return self.id == other.id
+        return False
+
+    @overrides
+    def __hash__(self):
+        return hash(str(self.id))
+
+
+def default_events_map() -> Diagram:
+    return Diagram('Events', id=uuid.UUID('6c74e40f-d3de-4c83-bcd2-0ca5e626081d'))
+
+
+def default_character_networks() -> List[Diagram]:
+    return [Diagram('Character relations', id=uuid.UUID('bfd1f2d3-cb33-48a6-a09e-b4332c3d1ed1'))]
 
 
 @dataclass
@@ -1802,6 +1829,8 @@ class Novel(NovelDescriptor):
     world: WorldBuilding = field(default_factory=WorldBuilding)
     board: Board = field(default_factory=Board)
     manuscript_goals: ManuscriptGoals = field(default_factory=ManuscriptGoals)
+    events_map: Diagram = field(default_factory=default_events_map)
+    character_networks: List[Diagram] = field(default_factory=default_character_networks)
 
     def pov_characters(self) -> List[Character]:
         pov_ids = set()

--- a/src/main/python/plotlyst/service/persistence.py
+++ b/src/main/python/plotlyst/service/persistence.py
@@ -148,6 +148,11 @@ class RepositoryPersistenceManager(QObject):
             self._operations.append(Operation(OperationType.UPDATE, novel=novel, doc=document))
             self._persist_if_test_env()
 
+    def update_diagram(self, novel: Novel, diagram: Diagram):
+        if self._persistence_enabled:
+            self._operations.append(Operation(OperationType.UPDATE, novel=novel, diagram=diagram))
+            self._persist_if_test_env()
+
     def delete_doc(self, novel: Novel, document: Document):
         if self._persistence_enabled:
             self._operations.append(Operation(OperationType.DELETE, novel=novel, doc=document))
@@ -188,6 +193,7 @@ def _persist_operations(operations: List[Operation]):
     updated_novel_cache: Set[Novel] = set()
     updated_scene_cache: Set[Scene] = set()
     updated_character_cache: Set[Character] = set()
+    updated_diagram_cache: Set[Diagram] = set()
 
     for op in operations:
         # scenes
@@ -210,13 +216,19 @@ def _persist_operations(operations: List[Operation]):
         elif op.character and op.novel and op.type == OperationType.DELETE:
             client.delete_character(op.novel, op.character)
 
-        # novel and document
+        # novel, document, diagram
         elif op.doc and op.type == OperationType.UPDATE:
             if op.doc not in updated_doc_cache:
-                json_client.save_document(op.novel, op.doc)
+                json_client.update_document(op.novel, op.doc)
                 updated_doc_cache.add(op.doc)
         elif op.doc and op.type == OperationType.DELETE:
             json_client.delete_document(op.novel, op.doc)
+
+        elif op.diagram and op.type == OperationType.UPDATE:
+            if op.diagram not in updated_diagram_cache:
+                json_client.update_diagram(op.novel, op.diagram)
+                updated_diagram_cache.add(op.diagram)
+
         elif op.novel and op.type == OperationType.UPDATE:
             if op.novel not in updated_novel_cache:
                 client.update_novel(op.novel)

--- a/src/main/python/plotlyst/service/persistence.py
+++ b/src/main/python/plotlyst/service/persistence.py
@@ -29,7 +29,7 @@ from overrides import overrides
 from qthandy import ask_confirmation
 
 from src.main.python.plotlyst.core.client import client, json_client
-from src.main.python.plotlyst.core.domain import Novel, Character, Scene, NovelDescriptor, Document, Plot
+from src.main.python.plotlyst.core.domain import Novel, Character, Scene, NovelDescriptor, Document, Plot, Diagram
 from src.main.python.plotlyst.env import app_env
 
 
@@ -48,6 +48,7 @@ class Operation:
     scene: Optional[Scene] = None
     update_image: bool = False
     doc: Optional[Document] = None
+    diagram: Optional[Diagram] = None
 
 
 class RepositoryPersistenceManager(QObject):

--- a/src/main/python/plotlyst/view/characters_view.py
+++ b/src/main/python/plotlyst/view/characters_view.py
@@ -256,6 +256,8 @@ class CharactersView(AbstractNovelView):
         elif self.ui.btnBackstoryView.isChecked():
             self.ui.wdgToolbar.setVisible(False)
             self.ui.wdgCharacterSelector.updateCharacters(self.novel.characters, checkAll=False)
+        elif self.ui.btnRelationsView.isChecked():
+            self._relations.refresh()
         elif self.ui.btnComparison.isChecked():
             self.ui.wdgToolbar.setVisible(False)
         else:

--- a/src/main/python/plotlyst/view/widget/character/network/editor.py
+++ b/src/main/python/plotlyst/view/widget/character/network/editor.py
@@ -25,7 +25,7 @@ from PyQt6.QtWidgets import QButtonGroup
 from qthandy import vline, retain_when_hidden
 from qtmenu import GridMenuWidget
 
-from src.main.python.plotlyst.core.domain import RelationsNetwork, Relation
+from src.main.python.plotlyst.core.domain import Diagram, Relation
 from src.main.python.plotlyst.view.common import tool_btn, action
 from src.main.python.plotlyst.view.dialog.utility import IconSelectorDialog
 from src.main.python.plotlyst.view.icons import IconRegistry
@@ -37,7 +37,7 @@ from src.main.python.plotlyst.view.widget.utility import ColorPicker
 class RelationSelector(GridMenuWidget):
     relationSelected = pyqtSignal(Relation)
 
-    def __init__(self, network: RelationsNetwork = None, parent=None):
+    def __init__(self, network: Diagram = None, parent=None):
         super().__init__(parent)
         self._network = network
         self._romance = Relation('Romance', icon='ei.heart', icon_color='#d1495b')
@@ -87,7 +87,7 @@ class RelationSelector(GridMenuWidget):
 
 
 class ConnectorEditor(BaseItemEditor):
-    def __init__(self, network: RelationsNetwork, parent=None):
+    def __init__(self, network: Diagram, parent=None):
         super().__init__(parent)
         self._connector: Optional[ConnectorItem] = None
 

--- a/src/main/python/plotlyst/view/widget/character/network/editor.py
+++ b/src/main/python/plotlyst/view/widget/character/network/editor.py
@@ -87,7 +87,7 @@ class RelationSelector(GridMenuWidget):
 
 
 class ConnectorEditor(BaseItemEditor):
-    def __init__(self, network: Diagram, parent=None):
+    def __init__(self, parent=None):
         super().__init__(parent)
         self._connector: Optional[ConnectorItem] = None
 
@@ -114,8 +114,7 @@ class ConnectorEditor(BaseItemEditor):
         self._sbWidth = PenWidthEditor()
         self._sbWidth.valueChanged.connect(self._widthChanged)
 
-        self._relationSelector = RelationSelector(network, self._btnRelationType)
-        self._relationSelector.relationSelected.connect(self._relationChanged)
+        self._relationSelector: Optional[RelationSelector] = None
 
         self._toolbar.layout().addWidget(self._btnRelationType)
         self._toolbar.layout().addWidget(vline())
@@ -127,6 +126,10 @@ class ConnectorEditor(BaseItemEditor):
         self._toolbar.layout().addWidget(self._dotLine)
         self._toolbar.layout().addWidget(vline())
         self._toolbar.layout().addWidget(self._sbWidth)
+
+    def setNetwork(self, diagram: Diagram):
+        self._relationSelector = RelationSelector(diagram, self._btnRelationType)
+        self._relationSelector.relationSelected.connect(self._relationChanged)
 
     def setItem(self, connector: ConnectorItem):
         self._connector = None

--- a/src/main/python/plotlyst/view/widget/character/network/scene.py
+++ b/src/main/python/plotlyst/view/widget/character/network/scene.py
@@ -26,7 +26,7 @@ from PyQt6.QtWidgets import QWidget, QStyleOptionGraphicsItem, QGraphicsSceneHov
 from overrides import overrides
 
 from src.main.python.plotlyst.common import PLOTLYST_SECONDARY_COLOR, PLOTLYST_TERTIARY_COLOR
-from src.main.python.plotlyst.core.domain import Character, Novel, RelationsNetwork, CharacterNode
+from src.main.python.plotlyst.core.domain import Character, Novel, Diagram, CharacterNode
 from src.main.python.plotlyst.view.common import pointy
 from src.main.python.plotlyst.view.icons import avatars
 from src.main.python.plotlyst.view.widget.graphics import NodeItem, AbstractSocketItem, NetworkItemType, \
@@ -154,7 +154,7 @@ class RelationsEditorScene(NetworkScene):
     def __init__(self, novel: Novel, parent=None):
         super(RelationsEditorScene, self).__init__(parent)
         self._novel = novel
-        self._network: Optional[RelationsNetwork] = None
+        self._network: Optional[Diagram] = None
 
         if self._novel.characters:
             node = CharacterNode(50, 50)
@@ -165,7 +165,7 @@ class RelationsEditorScene(NetworkScene):
             node.set_character(self._novel.characters[1])
             self.addItem(CharacterItem(self._novel.characters[1], node))
 
-    def setNetwork(self, network: RelationsNetwork):
+    def setNetwork(self, network: Diagram):
         self._network = network
 
     @staticmethod

--- a/src/main/python/plotlyst/view/widget/character/network/scene.py
+++ b/src/main/python/plotlyst/view/widget/character/network/scene.py
@@ -27,17 +27,11 @@ from overrides import overrides
 
 from src.main.python.plotlyst.common import PLOTLYST_SECONDARY_COLOR, PLOTLYST_TERTIARY_COLOR
 from src.main.python.plotlyst.core.client import json_client
-from src.main.python.plotlyst.core.domain import Character, Novel, Node
+from src.main.python.plotlyst.core.domain import Character, Novel, Node, DiagramNodeType
 from src.main.python.plotlyst.service.persistence import RepositoryPersistenceManager
 from src.main.python.plotlyst.view.common import pointy
 from src.main.python.plotlyst.view.icons import avatars
-from src.main.python.plotlyst.view.widget.graphics import NodeItem, AbstractSocketItem, NetworkItemType, \
-    NetworkScene
-
-
-class CharacterNetworkItemType(NetworkItemType):
-    CHARACTER = 1
-    STICKER = 2
+from src.main.python.plotlyst.view.widget.graphics import NodeItem, AbstractSocketItem, NetworkScene
 
 
 class PlaceholderCharacter(Character):
@@ -161,14 +155,14 @@ class RelationsEditorScene(NetworkScene):
 
     @staticmethod
     def toCharacterNode(scenePos: QPointF) -> Node:
-        node = Node(scenePos.x(), scenePos.y())
+        node = Node(scenePos.x(), scenePos.y(), type=DiagramNodeType.CHARACTER)
         node.x = node.x - CharacterItem.Margin
         node.y = node.y - CharacterItem.Margin
         return node
 
     @overrides
-    def _addNewItem(self, itemType: CharacterNetworkItemType, scenePos: QPointF) -> NodeItem:
-        if itemType == CharacterNetworkItemType.CHARACTER:
+    def _addNewItem(self, scenePos: QPointF, itemType: DiagramNodeType, subType: str = '') -> NodeItem:
+        if itemType == DiagramNodeType.CHARACTER:
             item = CharacterItem(PlaceholderCharacter('Character'), self.toCharacterNode(scenePos))
             self.addItem(item)
             self.itemAdded.emit(itemType, item)

--- a/src/main/python/plotlyst/view/widget/character/network/scene.py
+++ b/src/main/python/plotlyst/view/widget/character/network/scene.py
@@ -27,7 +27,7 @@ from overrides import overrides
 
 from src.main.python.plotlyst.common import PLOTLYST_SECONDARY_COLOR, PLOTLYST_TERTIARY_COLOR
 from src.main.python.plotlyst.core.client import json_client
-from src.main.python.plotlyst.core.domain import Character, Novel, CharacterNode
+from src.main.python.plotlyst.core.domain import Character, Novel, Node
 from src.main.python.plotlyst.service.persistence import RepositoryPersistenceManager
 from src.main.python.plotlyst.view.common import pointy
 from src.main.python.plotlyst.view.icons import avatars
@@ -65,7 +65,7 @@ class CharacterItem(NodeItem):
     Margin: int = 20
     PenWidth: int = 2
 
-    def __init__(self, character: Character, node: CharacterNode, parent=None):
+    def __init__(self, character: Character, node: Node, parent=None):
         super(CharacterItem, self).__init__(node, parent)
         self._character = character
         self._size: int = 68
@@ -160,19 +160,27 @@ class RelationsEditorScene(NetworkScene):
         self.repo = RepositoryPersistenceManager.instance()
 
     @staticmethod
-    def toCharacterNode(scenePos: QPointF) -> CharacterNode:
-        node = CharacterNode(scenePos.x(), scenePos.y())
+    def toCharacterNode(scenePos: QPointF) -> Node:
+        node = Node(scenePos.x(), scenePos.y())
         node.x = node.x - CharacterItem.Margin
         node.y = node.y - CharacterItem.Margin
         return node
 
     @overrides
-    def _addNewItem(self, itemType: CharacterNetworkItemType, scenePos: QPointF):
+    def _addNewItem(self, itemType: CharacterNetworkItemType, scenePos: QPointF) -> NodeItem:
         if itemType == CharacterNetworkItemType.CHARACTER:
             item = CharacterItem(PlaceholderCharacter('Character'), self.toCharacterNode(scenePos))
             self.addItem(item)
             self.itemAdded.emit(itemType, item)
         self.endAdditionMode()
+
+        return item
+
+    @overrides
+    def _addNode(self, node: Node):
+        character = node.character(self._novel) if node.character_id else PlaceholderCharacter('Character')
+        item = CharacterItem(character, node)
+        self.addItem(item)
 
     @overrides
     def _onLink(self, sourceNode: NodeItem, sourceSocket: AbstractSocketItem, targetNode: NodeItem,

--- a/src/main/python/plotlyst/view/widget/character/network/scene.py
+++ b/src/main/python/plotlyst/view/widget/character/network/scene.py
@@ -76,7 +76,20 @@ class CharacterItem(NodeItem):
 
     def setCharacter(self, character: Character):
         self._character = character
+        self._node.set_character(self._character)
         self.update()
+        self.networkScene().itemChangedEvent(self)
+
+    @overrides
+    def socket(self, angle: float) -> AbstractSocketItem:
+        angle_radians = math.radians(-angle)
+        x = self._center.x() + self._outerRadius * math.cos(angle_radians) - SocketItem.Size // 2
+        y = self._center.y() + self._outerRadius * math.sin(angle_radians) - SocketItem.Size // 2
+
+        self._socket.setAngle(angle)
+        self._socket.setPos(x, y)
+
+        return self._socket
 
     def addSocket(self, socket: SocketItem):
         self._sockets.append(socket)
@@ -123,10 +136,10 @@ class CharacterItem(NodeItem):
             angle_radians = math.radians(angle)
             x = self._center.x() + self._outerRadius * math.cos(angle_radians) - SocketItem.Size // 2
             y = self._center.y() + self._outerRadius * math.sin(angle_radians) - SocketItem.Size // 2
-
             self.prepareGeometryChange()
             self._socket.setAngle(-angle)
             self._socket.setPos(x, y)
+
             self.update()
 
     def relationsScene(self) -> 'RelationsEditorScene':
@@ -175,6 +188,8 @@ class RelationsEditorScene(NetworkScene):
         character = node.character(self._novel) if node.character_id else PlaceholderCharacter('Character')
         item = CharacterItem(character, node)
         self.addItem(item)
+
+        return item
 
     @overrides
     def _onLink(self, sourceNode: NodeItem, sourceSocket: AbstractSocketItem, targetNode: NodeItem,

--- a/src/main/python/plotlyst/view/widget/character/network/view.py
+++ b/src/main/python/plotlyst/view/widget/character/network/view.py
@@ -22,11 +22,10 @@ from typing import Optional
 from PyQt6.QtCore import QTimer
 from overrides import overrides
 
-from src.main.python.plotlyst.core.domain import Novel, Character
+from src.main.python.plotlyst.core.domain import Novel, Character, DiagramNodeType
 from src.main.python.plotlyst.view.icons import IconRegistry
 from src.main.python.plotlyst.view.widget.character.network.editor import ConnectorEditor
-from src.main.python.plotlyst.view.widget.character.network.scene import RelationsEditorScene, CharacterItem, \
-    NetworkItemType, CharacterNetworkItemType
+from src.main.python.plotlyst.view.widget.character.network.scene import RelationsEditorScene, CharacterItem
 from src.main.python.plotlyst.view.widget.characters import CharacterSelectorMenu
 from src.main.python.plotlyst.view.widget.graphics import NodeItem, NetworkGraphicsView, NetworkScene, ConnectorItem
 
@@ -37,9 +36,9 @@ class CharacterNetworkView(NetworkGraphicsView):
         super(CharacterNetworkView, self).__init__(parent)
 
         self._btnAddCharacter = self._newControlButton(IconRegistry.character_icon('#040406'), 'Add new character',
-                                                       CharacterNetworkItemType.CHARACTER)
+                                                       DiagramNodeType.CHARACTER)
         self._btnAddSticker = self._newControlButton(IconRegistry.from_name('mdi6.sticker-circle-outline'),
-                                                     'Add new sticker', CharacterNetworkItemType.STICKER)
+                                                     'Add new sticker', DiagramNodeType.STICKER)
 
         self._connectorEditor = ConnectorEditor(self)
         self._connectorEditor.setVisible(False)
@@ -59,14 +58,14 @@ class CharacterNetworkView(NetworkGraphicsView):
         return self._scene
 
     @overrides
-    def _startAddition(self, itemType: CharacterNetworkItemType):
+    def _startAddition(self, itemType: DiagramNodeType):
         super()._startAddition(itemType)
         self._scene.startAdditionMode(itemType)
 
     @overrides
-    def _endAddition(self, itemType: Optional[NetworkItemType] = None, item: Optional[NodeItem] = None):
+    def _endAddition(self, itemType: Optional[DiagramNodeType] = None, item: Optional[NodeItem] = None):
         super()._endAddition(itemType, item)
-        if itemType == CharacterNetworkItemType.CHARACTER:
+        if itemType == DiagramNodeType.CHARACTER:
             QTimer.singleShot(100, lambda: self._finishCharacterAddition(item))
 
     def _finishCharacterAddition(self, item: CharacterItem):

--- a/src/main/python/plotlyst/view/widget/character/network/view.py
+++ b/src/main/python/plotlyst/view/widget/character/network/view.py
@@ -22,7 +22,7 @@ from typing import Optional
 from PyQt6.QtCore import QTimer
 from overrides import overrides
 
-from src.main.python.plotlyst.core.domain import Novel, Diagram, Character
+from src.main.python.plotlyst.core.domain import Novel, Character
 from src.main.python.plotlyst.view.icons import IconRegistry
 from src.main.python.plotlyst.view.widget.character.network.editor import ConnectorEditor
 from src.main.python.plotlyst.view.widget.character.network.scene import RelationsEditorScene, CharacterItem, \
@@ -41,8 +41,7 @@ class CharacterNetworkView(NetworkGraphicsView):
         self._btnAddSticker = self._newControlButton(IconRegistry.from_name('mdi6.sticker-circle-outline'),
                                                      'Add new sticker', CharacterNetworkItemType.STICKER)
 
-        network = Diagram('Test')
-        self._connectorEditor = ConnectorEditor(network, self)
+        self._connectorEditor = ConnectorEditor(self)
         self._connectorEditor.setVisible(False)
 
         self._scene.selectionChanged.connect(self._selectionChanged)
@@ -51,18 +50,13 @@ class CharacterNetworkView(NetworkGraphicsView):
     def _initScene(self) -> NetworkScene:
         return RelationsEditorScene(self._novel)
 
+    def refresh(self):
+        if not self._diagram:
+            self.setDiagram(self._novel.character_networks[0])
+            self._connectorEditor.setNetwork(self._diagram)
+
     def relationsScene(self) -> RelationsEditorScene:
         return self._scene
-
-    def refresh(self, network: Diagram):
-        self._scene.clear()
-        self._scene.setNetwork(network)
-        for node in network.nodes:
-            item = CharacterItem(node.character(self._novel), node)
-            self._scene.addItem(item)
-            item.setPos(node.x, node.y)
-
-        self.centerOn(0, 0)
 
     @overrides
     def _startAddition(self, itemType: CharacterNetworkItemType):

--- a/src/main/python/plotlyst/view/widget/character/network/view.py
+++ b/src/main/python/plotlyst/view/widget/character/network/view.py
@@ -22,7 +22,7 @@ from typing import Optional
 from PyQt6.QtCore import QTimer
 from overrides import overrides
 
-from src.main.python.plotlyst.core.domain import Novel, RelationsNetwork, Character
+from src.main.python.plotlyst.core.domain import Novel, Diagram, Character
 from src.main.python.plotlyst.view.icons import IconRegistry
 from src.main.python.plotlyst.view.widget.character.network.editor import ConnectorEditor
 from src.main.python.plotlyst.view.widget.character.network.scene import RelationsEditorScene, CharacterItem, \
@@ -41,7 +41,7 @@ class CharacterNetworkView(NetworkGraphicsView):
         self._btnAddSticker = self._newControlButton(IconRegistry.from_name('mdi6.sticker-circle-outline'),
                                                      'Add new sticker', CharacterNetworkItemType.STICKER)
 
-        network = RelationsNetwork('Test')
+        network = Diagram('Test')
         self._connectorEditor = ConnectorEditor(network, self)
         self._connectorEditor.setVisible(False)
 
@@ -54,7 +54,7 @@ class CharacterNetworkView(NetworkGraphicsView):
     def relationsScene(self) -> RelationsEditorScene:
         return self._scene
 
-    def refresh(self, network: RelationsNetwork):
+    def refresh(self, network: Diagram):
         self._scene.clear()
         self._scene.setNetwork(network)
         for node in network.nodes:

--- a/src/main/python/plotlyst/view/widget/character/relations.py
+++ b/src/main/python/plotlyst/view/widget/character/relations.py
@@ -29,7 +29,7 @@ from qthandy import flow, transparent, pointy
 from qthandy.filter import OpacityEventFilter, DragEventFilter
 from qttoolbox import ToolBox
 
-from src.main.python.plotlyst.core.domain import Character, Novel, RelationsNetwork
+from src.main.python.plotlyst.core.domain import Character, Novel, Diagram
 from src.main.python.plotlyst.view.icons import avatars, IconRegistry
 
 
@@ -100,7 +100,7 @@ class _CharacterSelectorAvatar(QToolButton):
 
 
 class NetworkPanel(QWidget):
-    def __init__(self, novel: Novel, network: RelationsNetwork, parent=None):
+    def __init__(self, novel: Novel, network: Diagram, parent=None):
         super(NetworkPanel, self).__init__(parent)
         self._novel = novel
         self._network = network
@@ -112,7 +112,7 @@ class NetworkPanel(QWidget):
 
         self.updateAvatars()
 
-    def network(self) -> RelationsNetwork:
+    def network(self) -> Diagram:
         return self._network
 
     def updateAvatars(self):
@@ -125,17 +125,17 @@ class NetworkPanel(QWidget):
 
 
 class RelationsSelectorBox(ToolBox):
-    relationsSelected = pyqtSignal(RelationsNetwork)
+    relationsSelected = pyqtSignal(Diagram)
 
     def __init__(self, novel: Novel, parent=None):
         super(RelationsSelectorBox, self).__init__(parent)
         self._novel = novel
 
-    def addNetwork(self, network: RelationsNetwork):
+    def addNetwork(self, network: Diagram):
         wdg = NetworkPanel(self._novel, network)
         self.addItem(wdg, network.title, icon=IconRegistry.from_name(network.icon, network.icon_color))
 
-    def refreshCharacters(self, network: RelationsNetwork):
+    def refreshCharacters(self, network: Diagram):
         panel = self.currentWidget()
         if panel.network() is network:
             panel.updateAvatars()

--- a/src/main/python/plotlyst/view/widget/graphics.py
+++ b/src/main/python/plotlyst/view/widget/graphics.py
@@ -392,6 +392,7 @@ class NodeItem(QAbstractGraphicsShapeItem):
         self._posChangedTimer.stop()
         self._node.x = self.scenePos().x()
         self._node.y = self.scenePos().y()
+        self.networkScene().itemChangedEvent(self)
 
 
 class BaseGraphicsView(QGraphicsView):

--- a/src/main/python/plotlyst/view/widget/story_map/controls.py
+++ b/src/main/python/plotlyst/view/widget/story_map/controls.py
@@ -21,9 +21,11 @@ from PyQt6.QtGui import QShowEvent
 from PyQt6.QtWidgets import QLabel
 from overrides import overrides
 
+from src.main.python.plotlyst.core.domain import DiagramNodeType, NODE_SUBTYPE_GOAL, NODE_SUBTYPE_CONFLICT, \
+    NODE_SUBTYPE_DISTURBANCE, NODE_SUBTYPE_BACKSTORY, NODE_SUBTYPE_QUESTION, NODE_SUBTYPE_FORESHADOWING, \
+    NODE_SUBTYPE_TOOL, NODE_SUBTYPE_COST
 from src.main.python.plotlyst.view.icons import IconRegistry
 from src.main.python.plotlyst.view.widget.graphics import SecondarySelectorWidget
-from src.main.python.plotlyst.view.widget.story_map.items import ItemType
 
 
 class EventSelectorWidget(SecondarySelectorWidget):
@@ -31,30 +33,33 @@ class EventSelectorWidget(SecondarySelectorWidget):
         super().__init__(parent)
         self._grid.addWidget(QLabel('Events'), 0, 0, 1, 3)
 
-        self._btnGeneral = self.addItemTypeButton(ItemType.EVENT, IconRegistry.from_name('mdi.square-rounded-outline'),
-                                                   'General event', 1, 0)
-        self._btnGoal = self.addItemTypeButton(ItemType.GOAL, IconRegistry.goal_icon('black', 'black'), 'Add new goal',
-                                               1, 1)
-        self._btnConflict = self.addItemTypeButton(ItemType.CONFLICT, IconRegistry.conflict_icon('black', 'black'),
-                                                    'Conflict', 1, 2)
-        self._btnDisturbance = self.addItemTypeButton(ItemType.DISTURBANCE,
+        self._btnGeneral = self.addItemTypeButton(DiagramNodeType.EVENT,
+                                                  IconRegistry.from_name('mdi.square-rounded-outline'),
+                                                  'General event', 1, 0)
+        self._btnGoal = self.addItemTypeButton(DiagramNodeType.EVENT, IconRegistry.goal_icon('black', 'black'),
+                                               'Add new goal',
+                                               1, 1, subType=NODE_SUBTYPE_GOAL)
+        self._btnConflict = self.addItemTypeButton(DiagramNodeType.EVENT,
+                                                   IconRegistry.conflict_icon('black', 'black'),
+                                                   'Conflict', 1, 2, subType=NODE_SUBTYPE_CONFLICT)
+        self._btnDisturbance = self.addItemTypeButton(DiagramNodeType.EVENT,
                                                       IconRegistry.inciting_incident_icon('black'),
-                                                       'Inciting incident', 2,
-                                                      0)
-        self._btnBackstory = self.addItemTypeButton(ItemType.BACKSTORY, IconRegistry.backstory_icon('black', 'black'),
-                                                     'Backstory', 2, 1)
+                                                      'Inciting incident', 2,
+                                                      0, subType=NODE_SUBTYPE_DISTURBANCE)
+        self._btnBackstory = self.addItemTypeButton(DiagramNodeType.EVENT,
+                                                    IconRegistry.backstory_icon('black', 'black'),
+                                                    'Backstory', 2, 1, subType=NODE_SUBTYPE_BACKSTORY)
 
         self._grid.addWidget(QLabel('Narrative'), 3, 0, 1, 3)
-        self._btnQuestion = self.addItemTypeButton(ItemType.QUESTION, IconRegistry.from_name('ei.question-sign'),
-                                                    "Reader's question", 4,
-                                                   0)
-        self._btnSetup = self.addItemTypeButton(ItemType.SETUP, IconRegistry.from_name('ri.seedling-fill'),
-                                                 'Setup and payoff', 4, 1)
-        self._btnForeshadowing = self.addItemTypeButton(ItemType.FORESHADOWING,
+        self._btnQuestion = self.addItemTypeButton(DiagramNodeType.SETUP, IconRegistry.from_name('ei.question-sign'),
+                                                   "Reader's question", 4,
+                                                   0, subType=NODE_SUBTYPE_QUESTION)
+        self._btnSetup = self.addItemTypeButton(DiagramNodeType.SETUP, IconRegistry.from_name('ri.seedling-fill'),
+                                                'Setup and payoff', 4, 1)
+        self._btnForeshadowing = self.addItemTypeButton(DiagramNodeType.SETUP,
                                                         IconRegistry.from_name('mdi6.crystal-ball'),
-                                                         'Foreshadowing',
-                                                        4,
-                                                        2)
+                                                        'Foreshadowing',
+                                                        4, 2, subType=NODE_SUBTYPE_FORESHADOWING)
 
         self._btnGeneral.setChecked(True)
 
@@ -66,12 +71,15 @@ class EventSelectorWidget(SecondarySelectorWidget):
 class StickerSelectorWidget(SecondarySelectorWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
-        self._btnComment = self.addItemTypeButton(ItemType.COMMENT, IconRegistry.from_name('mdi.comment-text-outline'),
-                                                   'Add new comment', 0, 0)
-        self._btnTool = self.addItemTypeButton(ItemType.TOOL, IconRegistry.tool_icon('black', 'black'), 'Add new tool',
-                                               0, 1)
-        self._btnCost = self.addItemTypeButton(ItemType.COST, IconRegistry.cost_icon('black', 'black'), 'Add new cost',
-                                               1, 0)
+        self._btnComment = self.addItemTypeButton(DiagramNodeType.COMMENT,
+                                                  IconRegistry.from_name('mdi.comment-text-outline'),
+                                                  'Add new comment', 0, 0)
+        self._btnTool = self.addItemTypeButton(DiagramNodeType.STICKER, IconRegistry.tool_icon('black', 'black'),
+                                               'Add new tool',
+                                               0, 1, subType=NODE_SUBTYPE_TOOL)
+        self._btnCost = self.addItemTypeButton(DiagramNodeType.STICKER, IconRegistry.cost_icon('black', 'black'),
+                                               'Add new cost',
+                                               1, 0, subType=NODE_SUBTYPE_COST)
 
         self._btnComment.setChecked(True)
 

--- a/src/main/python/plotlyst/view/widget/story_map/editors.py
+++ b/src/main/python/plotlyst/view/widget/story_map/editors.py
@@ -27,13 +27,14 @@ from qthandy import hbox, margins, transparent, vline
 from qtmenu import MenuWidget
 
 from src.main.python.plotlyst.common import PLOTLYST_SECONDARY_COLOR
+from src.main.python.plotlyst.core.domain import DiagramNodeType
 from src.main.python.plotlyst.view.common import tool_btn
 from src.main.python.plotlyst.view.dialog.utility import IconSelectorDialog
 from src.main.python.plotlyst.view.icons import IconRegistry
 from src.main.python.plotlyst.view.widget.graphics import BaseItemEditor
 from src.main.python.plotlyst.view.widget.input import AutoAdjustableLineEdit, FontSizeSpinBox
 from src.main.python.plotlyst.view.widget.story_map.controls import EventSelectorWidget
-from src.main.python.plotlyst.view.widget.story_map.items import EventItem, ItemType
+from src.main.python.plotlyst.view.widget.story_map.items import EventItem
 
 
 class StickerEditor(QWidget):
@@ -136,7 +137,7 @@ class EventItemEditor(BaseItemEditor):
             self._item.setFontSettings(bold=self._btnBold.isChecked(), italic=self._btnItalic.isChecked(),
                                        underline=self._btnUnderline.isChecked())
 
-    def _typeChanged(self, itemType: ItemType):
+    def _typeChanged(self, itemType: DiagramNodeType):
         if self._item:
             self._item.setItemType(itemType)
 

--- a/src/main/python/plotlyst/view/widget/story_map/items.py
+++ b/src/main/python/plotlyst/view/widget/story_map/items.py
@@ -133,7 +133,10 @@ class EventItem(ConnectableNode):
 
     def __init__(self, node: Node, parent=None):
         super().__init__(node, parent)
-        self._text: str = 'New event'
+        if self._node.text:
+            self._text = self._node.text
+        else:
+            self._text: str = 'New event'
         self._icon: Optional[QIcon] = None
         self._iconSize: int = 0
         self._iconTextSpacing: int = 3
@@ -168,11 +171,32 @@ class EventItem(ConnectableNode):
 
     def setText(self, text: str):
         self._text = text
+        self._node.text = text
         self.setSelected(False)
         self._refresh()
+        self.networkScene().itemChangedEvent(self)
 
     def DiagramNodeType(self) -> DiagramNodeType:
         return self._DiagramNodeType
+
+    @overrides
+    def socket(self, angle: float) -> AbstractSocketItem:
+        if angle == 0:
+            return self._socketRight
+        elif angle == 45:
+            return self._socketTopRight
+        elif angle == 90:
+            return self._socketTopCenter
+        elif angle == 135:
+            return self._socketTopLeft
+        elif angle == 180:
+            return self._socketLeft
+        elif angle == -135:
+            return self._socketBottomLeft
+        elif angle == -90:
+            return self._socketBottomCenter
+        elif angle == -45:
+            return self._socketBottomRight
 
     def setIcon(self, icon: QIcon):
         self._icon = icon
@@ -317,6 +341,17 @@ class CharacterItem(ConnectableNode):
     @overrides
     def boundingRect(self) -> QRectF:
         return QRectF(0, 0, self._size + self.Margin * 2, self._size + self.Margin * 2)
+
+    @overrides
+    def socket(self, angle: float) -> AbstractSocketItem:
+        if angle == 0:
+            return self._socketRight
+        elif angle == 90:
+            return self._socketTop
+        elif angle == 180:
+            return self._socketLeft
+        elif angle == -90:
+            return self._socketBottom
 
     def setCharacter(self, character: Character):
         self._character = character

--- a/src/main/python/plotlyst/view/widget/story_map/items.py
+++ b/src/main/python/plotlyst/view/widget/story_map/items.py
@@ -26,28 +26,15 @@ from PyQt6.QtWidgets import QWidget, QApplication, QStyleOptionGraphicsItem, \
 from overrides import overrides
 
 from src.main.python.plotlyst.common import PLOTLYST_SECONDARY_COLOR, RELAXED_WHITE_COLOR
-from src.main.python.plotlyst.core.domain import Character, Node
+from src.main.python.plotlyst.core.domain import Character, Node, DiagramNodeType, NODE_SUBTYPE_GOAL, \
+    NODE_SUBTYPE_CONFLICT, NODE_SUBTYPE_BACKSTORY, NODE_SUBTYPE_DISTURBANCE, NODE_SUBTYPE_QUESTION, \
+    NODE_SUBTYPE_FORESHADOWING
 from src.main.python.plotlyst.view.icons import IconRegistry, avatars
-from src.main.python.plotlyst.view.widget.graphics import NodeItem, AbstractSocketItem, NetworkItemType
+from src.main.python.plotlyst.view.widget.graphics import NodeItem, AbstractSocketItem
 
 
 def v_center(ref_height: int, item_height: int) -> int:
     return (ref_height - item_height) // 2
-
-
-class ItemType(NetworkItemType):
-    EVENT = 1
-    CHARACTER = 2
-    GOAL = 3
-    CONFLICT = 4
-    DISTURBANCE = 5
-    BACKSTORY = 6
-    SETUP = 7
-    QUESTION = 8
-    FORESHADOWING = 9
-    COMMENT = 10
-    TOOL = 11
-    COST = 12
 
 
 class MindMapNode(NodeItem):
@@ -79,14 +66,14 @@ class SocketItem(AbstractSocketItem):
 class StickerItem(MindMapNode):
     displayMessage = pyqtSignal()
 
-    def __init__(self, node: Node, type: ItemType, parent=None):
+    def __init__(self, node: Node, parent=None):
         super().__init__(node, parent)
         self._size = 28
-        if type == ItemType.COMMENT:
+        if type == DiagramNodeType.COMMENT:
             self._icon = IconRegistry.from_name('mdi.comment-text', PLOTLYST_SECONDARY_COLOR)
-        elif type == ItemType.TOOL:
+        elif type == DiagramNodeType.TOOL:
             self._icon = IconRegistry.tool_icon()
-        if type == ItemType.COST:
+        if type == DiagramNodeType.COST:
             self._icon = IconRegistry.cost_icon()
 
         self.setFlag(
@@ -144,10 +131,9 @@ class EventItem(ConnectableNode):
     Margin: int = 30
     Padding: int = 20
 
-    def __init__(self, node: Node, itemType: ItemType, parent=None):
+    def __init__(self, node: Node, parent=None):
         super().__init__(node, parent)
         self._text: str = 'New event'
-        self._itemType = itemType
         self._icon: Optional[QIcon] = None
         self._iconSize: int = 0
         self._iconTextSpacing: int = 3
@@ -185,8 +171,8 @@ class EventItem(ConnectableNode):
         self.setSelected(False)
         self._refresh()
 
-    def itemType(self) -> ItemType:
-        return self._itemType
+    def DiagramNodeType(self) -> DiagramNodeType:
+        return self._DiagramNodeType
 
     def setIcon(self, icon: QIcon):
         self._icon = icon
@@ -207,8 +193,8 @@ class EventItem(ConnectableNode):
 
         self._refresh()
 
-    def setItemType(self, itemType: ItemType):
-        self._itemType = itemType
+    def setDiagramNodeType(self, DiagramNodeType: DiagramNodeType):
+        self._DiagramNodeType = DiagramNodeType
         self._updateIcon()
 
         self._refresh()
@@ -264,19 +250,19 @@ class EventItem(ConnectableNode):
         self.update()
 
     def _updateIcon(self):
-        if self._itemType == ItemType.GOAL:
+        if self._node.subtype == NODE_SUBTYPE_GOAL:
             self._icon = IconRegistry.goal_icon()
-        elif self._itemType == ItemType.CONFLICT:
+        elif self._node.subtype == NODE_SUBTYPE_CONFLICT:
             self._icon = IconRegistry.conflict_icon()
-        elif self._itemType == ItemType.BACKSTORY:
+        elif self._node.subtype == NODE_SUBTYPE_BACKSTORY:
             self._icon = IconRegistry.backstory_icon()
-        elif self._itemType == ItemType.DISTURBANCE:
+        elif self._node.subtype == NODE_SUBTYPE_DISTURBANCE:
             self._icon = IconRegistry.inciting_incident_icon()
-        elif self._itemType == ItemType.QUESTION:
+        elif self._node.subtype == NODE_SUBTYPE_QUESTION:
             self._icon = IconRegistry.from_name('ei.question-sign')
-        elif self._itemType == ItemType.SETUP:
+        elif self._node.subtype == DiagramNodeType.SETUP:
             self._icon = IconRegistry.from_name('ri.seedling-fill')
-        elif self._itemType == ItemType.FORESHADOWING:
+        elif self._node.subtype == NODE_SUBTYPE_FORESHADOWING:
             self._icon = IconRegistry.from_name('mdi6.crystal-ball')
 
     def _recalculateRect(self):

--- a/src/main/python/plotlyst/view/widget/story_map/scene.py
+++ b/src/main/python/plotlyst/view/widget/story_map/scene.py
@@ -23,10 +23,10 @@ from PyQt6.QtGui import QKeyEvent
 from overrides import overrides
 
 from src.main.python.plotlyst.core.client import json_client
-from src.main.python.plotlyst.core.domain import Node, CharacterNode
+from src.main.python.plotlyst.core.domain import Node
 from src.main.python.plotlyst.core.domain import Novel
 from src.main.python.plotlyst.service.persistence import RepositoryPersistenceManager
-from src.main.python.plotlyst.view.widget.graphics import NetworkScene
+from src.main.python.plotlyst.view.widget.graphics import NetworkScene, NodeItem
 from src.main.python.plotlyst.view.widget.story_map.items import ItemType, MindMapNode, EventItem, StickerItem, \
     CharacterItem, SocketItem
 
@@ -41,16 +41,6 @@ class EventsMindMapScene(NetworkScene):
     def __init__(self, novel: Novel, parent=None):
         super().__init__(parent)
         self._novel = novel
-
-        if novel.characters:
-            characterItem = CharacterItem(CharacterNode(50, 50), novel.characters[0])
-
-            self.addItem(characterItem)
-        eventItem = EventItem(Node(400, 100), ItemType.EVENT)
-        self.addItem(eventItem)
-
-        sticker = StickerItem(Node(200, 0), ItemType.COMMENT)
-        self.addItem(sticker)
 
         self.repo = RepositoryPersistenceManager.instance()
 
@@ -85,7 +75,7 @@ class EventsMindMapScene(NetworkScene):
         self.closeSticker.emit()
 
     @overrides
-    def _addNewItem(self, itemType: ItemType, scenePos: QPointF):
+    def _addNewItem(self, itemType: ItemType, scenePos: QPointF) -> NodeItem:
         if itemType == ItemType.CHARACTER:
             item = CharacterItem(self.toCharacterNode(scenePos), character=None)
         elif itemType in [ItemType.COMMENT, ItemType.TOOL, ItemType.COST]:
@@ -96,6 +86,12 @@ class EventsMindMapScene(NetworkScene):
         self.addItem(item)
         self.itemAdded.emit(itemType, item)
         self.endAdditionMode()
+
+        return item
+
+    @overrides
+    def _addNode(self, node: Node):
+        pass
 
     @staticmethod
     def toEventNode(scenePos: QPointF) -> Node:

--- a/src/main/python/plotlyst/view/widget/story_map/scene.py
+++ b/src/main/python/plotlyst/view/widget/story_map/scene.py
@@ -100,6 +100,7 @@ class EventsMindMapScene(NetworkScene):
             item = EventItem(node)
 
         self.addItem(item)
+        return item
 
     @staticmethod
     def toEventNode(scenePos: QPointF, itemType: DiagramNodeType, subType: str = '') -> Node:

--- a/src/main/python/plotlyst/view/widget/story_map/scene.py
+++ b/src/main/python/plotlyst/view/widget/story_map/scene.py
@@ -23,11 +23,11 @@ from PyQt6.QtGui import QKeyEvent
 from overrides import overrides
 
 from src.main.python.plotlyst.core.client import json_client
-from src.main.python.plotlyst.core.domain import Node
+from src.main.python.plotlyst.core.domain import Node, DiagramNodeType
 from src.main.python.plotlyst.core.domain import Novel
 from src.main.python.plotlyst.service.persistence import RepositoryPersistenceManager
 from src.main.python.plotlyst.view.widget.graphics import NetworkScene, NodeItem
-from src.main.python.plotlyst.view.widget.story_map.items import ItemType, MindMapNode, EventItem, StickerItem, \
+from src.main.python.plotlyst.view.widget.story_map.items import MindMapNode, EventItem, StickerItem, \
     CharacterItem, SocketItem
 
 
@@ -75,13 +75,13 @@ class EventsMindMapScene(NetworkScene):
         self.closeSticker.emit()
 
     @overrides
-    def _addNewItem(self, itemType: ItemType, scenePos: QPointF) -> NodeItem:
-        if itemType == ItemType.CHARACTER:
-            item = CharacterItem(self.toCharacterNode(scenePos), character=None)
-        elif itemType in [ItemType.COMMENT, ItemType.TOOL, ItemType.COST]:
-            item = StickerItem(Node(scenePos.x(), scenePos.y()), itemType)
+    def _addNewItem(self, scenePos: QPointF, itemType: DiagramNodeType, subType: str = '') -> NodeItem:
+        if itemType == DiagramNodeType.CHARACTER:
+            item = CharacterItem(self.toCharacterNode(scenePos, itemType), character=None)
+        elif itemType in [DiagramNodeType.COMMENT, DiagramNodeType.STICKER]:
+            item = StickerItem(Node(scenePos.x(), scenePos.y(), itemType, subType))
         else:
-            item = EventItem(self.toEventNode(scenePos), itemType)
+            item = EventItem(self.toEventNode(scenePos, itemType, subType))
 
         self.addItem(item)
         self.itemAdded.emit(itemType, item)
@@ -94,15 +94,15 @@ class EventsMindMapScene(NetworkScene):
         pass
 
     @staticmethod
-    def toEventNode(scenePos: QPointF) -> Node:
-        node = Node(scenePos.x(), scenePos.y())
+    def toEventNode(scenePos: QPointF, itemType: DiagramNodeType, subType: str = '') -> Node:
+        node = Node(scenePos.x(), scenePos.y(), itemType, subType)
         node.x = node.x - EventItem.Margin - EventItem.Padding
         node.y = node.y - EventItem.Margin - EventItem.Padding
         return node
 
     @staticmethod
-    def toCharacterNode(scenePos: QPointF) -> Node:
-        node = Node(scenePos.x(), scenePos.y())
+    def toCharacterNode(scenePos: QPointF, itemType: DiagramNodeType) -> Node:
+        node = Node(scenePos.x(), scenePos.y(), itemType)
         node.x = node.x - CharacterItem.Margin
         node.y = node.y - CharacterItem.Margin
         return node

--- a/src/main/python/plotlyst/view/widget/story_map/scene.py
+++ b/src/main/python/plotlyst/view/widget/story_map/scene.py
@@ -91,7 +91,15 @@ class EventsMindMapScene(NetworkScene):
 
     @overrides
     def _addNode(self, node: Node):
-        pass
+        if node.type == DiagramNodeType.CHARACTER:
+            character = node.character(self._novel) if node.character_id else None
+            item = CharacterItem(node, character)
+        elif node.type in [DiagramNodeType.COMMENT, DiagramNodeType.STICKER]:
+            item = StickerItem(node)
+        else:
+            item = EventItem(node)
+
+        self.addItem(item)
 
     @staticmethod
     def toEventNode(scenePos: QPointF, itemType: DiagramNodeType, subType: str = '') -> Node:

--- a/src/main/python/plotlyst/view/widget/story_map/scene.py
+++ b/src/main/python/plotlyst/view/widget/story_map/scene.py
@@ -18,12 +18,14 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-from PyQt6.QtCore import Qt, pyqtSignal, QPointF
+from PyQt6.QtCore import pyqtSignal, QPointF
 from PyQt6.QtGui import QKeyEvent
 from overrides import overrides
 
+from src.main.python.plotlyst.core.client import json_client
 from src.main.python.plotlyst.core.domain import Node, CharacterNode
 from src.main.python.plotlyst.core.domain import Novel
+from src.main.python.plotlyst.service.persistence import RepositoryPersistenceManager
 from src.main.python.plotlyst.view.widget.graphics import NetworkScene
 from src.main.python.plotlyst.view.widget.story_map.items import ItemType, MindMapNode, EventItem, StickerItem, \
     CharacterItem, SocketItem
@@ -49,6 +51,8 @@ class EventsMindMapScene(NetworkScene):
 
         sticker = StickerItem(Node(200, 0), ItemType.COMMENT)
         self.addItem(sticker)
+
+        self.repo = RepositoryPersistenceManager.instance()
 
     @overrides
     def startLink(self, source: SocketItem):
@@ -106,3 +110,11 @@ class EventsMindMapScene(NetworkScene):
         node.x = node.x - CharacterItem.Margin
         node.y = node.y - CharacterItem.Margin
         return node
+
+    @overrides
+    def _load(self):
+        json_client.load_diagram(self._novel, self._diagram)
+
+    @overrides
+    def _save(self):
+        self.repo.update_diagram(self._novel, self._diagram)

--- a/src/main/python/plotlyst/view/widget/story_map/view.py
+++ b/src/main/python/plotlyst/view/widget/story_map/view.py
@@ -21,6 +21,7 @@ from typing import Optional
 
 import qtanim
 from PyQt6.QtCore import QTimer
+from PyQt6.QtGui import QShowEvent
 from overrides import overrides
 
 from src.main.python.plotlyst.core.domain import Character
@@ -72,6 +73,11 @@ class EventsMindMapView(NetworkGraphicsView):
     @overrides
     def _initScene(self) -> NetworkScene:
         return EventsMindMapScene(self._novel)
+
+    @overrides
+    def showEvent(self, event: QShowEvent) -> None:
+        if self._diagram is None:
+            self.setDiagram(self._novel.events_map)
 
     def _editEvent(self, item: EventItem):
         def setText(text: str):

--- a/src/main/python/plotlyst/view/widget/story_map/view.py
+++ b/src/main/python/plotlyst/view/widget/story_map/view.py
@@ -24,14 +24,14 @@ from PyQt6.QtCore import QTimer
 from PyQt6.QtGui import QShowEvent
 from overrides import overrides
 
-from src.main.python.plotlyst.core.domain import Character
+from src.main.python.plotlyst.core.domain import Character, DiagramNodeType
 from src.main.python.plotlyst.core.domain import Novel
 from src.main.python.plotlyst.view.icons import IconRegistry
 from src.main.python.plotlyst.view.widget.characters import CharacterSelectorMenu
 from src.main.python.plotlyst.view.widget.graphics import NetworkGraphicsView, NetworkScene
 from src.main.python.plotlyst.view.widget.story_map.controls import EventSelectorWidget, StickerSelectorWidget
 from src.main.python.plotlyst.view.widget.story_map.editors import StickerEditor, TextLineEditorPopup, EventItemEditor
-from src.main.python.plotlyst.view.widget.story_map.items import EventItem, StickerItem, ItemType, MindMapNode, \
+from src.main.python.plotlyst.view.widget.story_map.items import EventItem, StickerItem, MindMapNode, \
     CharacterItem
 from src.main.python.plotlyst.view.widget.story_map.scene import EventsMindMapScene
 
@@ -42,12 +42,12 @@ class EventsMindMapView(NetworkGraphicsView):
         self._novel = novel
         super().__init__(parent)
         self._btnAddEvent = self._newControlButton(
-            IconRegistry.from_name('mdi6.shape-square-rounded-plus'), 'Add new event', ItemType.EVENT)
+            IconRegistry.from_name('mdi6.shape-square-rounded-plus'), 'Add new event', DiagramNodeType.EVENT)
         self._btnAddCharacter = self._newControlButton(
-            IconRegistry.character_icon('#040406'), 'Add new character', ItemType.CHARACTER)
+            IconRegistry.character_icon('#040406'), 'Add new character', DiagramNodeType.CHARACTER)
         self._btnAddSticker = self._newControlButton(IconRegistry.from_name('mdi6.sticker-circle-outline'),
                                                      'Add new sticker',
-                                                     ItemType.COMMENT)
+                                                     DiagramNodeType.COMMENT)
 
         self._wdgSecondaryEventSelector = EventSelectorWidget(self)
         self._wdgSecondaryEventSelector.setVisible(False)
@@ -106,27 +106,27 @@ class EventsMindMapView(NetworkGraphicsView):
         self._itemEditor.setVisible(False)
 
     @overrides
-    def _startAddition(self, itemType: ItemType):
-        super()._startAddition(itemType)
+    def _startAddition(self, itemType: DiagramNodeType, subType: str = ''):
+        super()._startAddition(itemType, subType)
         self._hideItemEditor()
 
-        if itemType == ItemType.EVENT:
+        if itemType == DiagramNodeType.EVENT:
             self._wdgSecondaryEventSelector.setVisible(True)
             self._wdgSecondaryStickerSelector.setHidden(True)
-        elif itemType == ItemType.COMMENT:
+        elif itemType == DiagramNodeType.COMMENT:
             self._wdgSecondaryStickerSelector.setVisible(True)
             self._wdgSecondaryEventSelector.setHidden(True)
-        elif itemType == ItemType.CHARACTER:
+        elif itemType == DiagramNodeType.CHARACTER:
             self._wdgSecondaryStickerSelector.setHidden(True)
             self._wdgSecondaryEventSelector.setHidden(True)
 
     @overrides
-    def _endAddition(self, itemType: Optional[ItemType] = None, item: Optional[MindMapNode] = None):
+    def _endAddition(self, itemType: Optional[DiagramNodeType] = None, item: Optional[MindMapNode] = None):
         super()._endAddition(itemType, item)
         self._wdgSecondaryEventSelector.setHidden(True)
         self._wdgSecondaryStickerSelector.setHidden(True)
 
-        if itemType == ItemType.CHARACTER:
+        if itemType == DiagramNodeType.CHARACTER:
             QTimer.singleShot(100, lambda: self._finishCharacterAddition(item))
 
     def _finishCharacterAddition(self, item: CharacterItem):


### PR DESCRIPTION
- [x] client: save under new diagrams folder
- [x] handle operation in service
- [x] eventmap in novel
- [x] load diagram api
- [x] load events map on demand
- [x] character networks in novel
- [x] load characters network on demand
- [x] persist nodes position
- [x] persist character nodes
- [x] restore nodes
- [x] persist connectors
  - [x] connector domain
    - [x] type
    - [x] icon
    - [x] color
    - [x] text
    - [x] width
    - [x] penstyle
    - [x] source, target id
    - [x] source/target angle
  - [x] save source angle
  - [x] save target angle
- [x] restore connectors
  - [x] find source/target node
  - [x] restore connector type and style
  - [x] restore exact angles
- [x] save item pos change
- [x] add connector to ConnectorItem
- [x] save connector style changes
- [x] save removed connectors