### PR TITLE
Move scene outcome selector to the top row

### DIFF
--- a/src/main/python/plotlyst/view/scene_editor.py
+++ b/src/main/python/plotlyst/view/scene_editor.py
@@ -152,7 +152,7 @@ class SceneEditor(QObject, EventListener):
         self.ui.wdgSceneStructure.timeline.outcomeChanged.connect(self._storylineEditor.refresh)
 
         self._update_view(scene)
-        self.ui.tabWidget.setCurrentWidget(self.ui.tabCharacter)
+        self.ui.tabWidget.setCurrentWidget(self.ui.tabStorylines)
         self.ui.tabWidget.currentChanged.connect(self._page_toggled)
 
         self.repo = RepositoryPersistenceManager.instance()

--- a/src/main/python/plotlyst/view/scene_editor.py
+++ b/src/main/python/plotlyst/view/scene_editor.py
@@ -308,6 +308,7 @@ class SceneEditor(QObject, EventListener):
         # to avoid segfault for some reason, we disable it first before changing the stack widget
         self._purposeSelector.setDisabled(True)
         self.ui.stackedWidget.setCurrentWidget(self.ui.pageEditor)
+        self._storylineEditor.purposeChangedEvent()
 
     def _reset_purpose_editor(self):
         self.scene.purpose = None

--- a/src/main/python/plotlyst/view/widget/scene/agency.py
+++ b/src/main/python/plotlyst/view/widget/scene/agency.py
@@ -196,7 +196,7 @@ class AbstractAgencyEditor(QWidget):
         self._activated: bool = False
 
         self._icon = push_btn(QIcon(), transparent_=True)
-        self._icon.setIconSize(QSize(32, 32))
+        self._icon.setIconSize(QSize(28, 28))
         self._opacityFilter = OpacityEventFilter(self._icon)
         self._icon.clicked.connect(self._iconClicked)
 
@@ -442,8 +442,6 @@ class SceneAgendaConflictEditor(AbstractAgencyEditor):
         clear_layout(self._wdgConflicts)
 
         if agenda.intensity > 0 or agenda.conflict_references:
-            print(agenda.intensity)
-            print(len(agenda.conflict_references))
             self.setValue(agenda.intensity)
         else:
             self.reset()

--- a/src/main/python/plotlyst/view/widget/scene/editor.py
+++ b/src/main/python/plotlyst/view/widget/scene/editor.py
@@ -1097,7 +1097,8 @@ class SceneStorylineEditor(AbstractSceneElementsEditor):
         self._wdgHeader.layout().setSpacing(5)
         self._wdgHeader.layout().addWidget(self._outcomeEditor)
         self._wdgHeader.layout().addWidget(spacer())
-        self._wdgElementsParent.layout().insertWidget(1, line())
+        self._headerLine = line()
+        self._wdgElementsParent.layout().insertWidget(1, self._headerLine)
 
         self._row = 3
         self._col = 5
@@ -1151,6 +1152,7 @@ class SceneStorylineEditor(AbstractSceneElementsEditor):
     @overrides
     def setScene(self, scene: Scene):
         super().setScene(scene)
+        self.purposeChangedEvent()
         self._outcomeEditor.setScene(scene)
 
         for row in range(self._row):
@@ -1166,6 +1168,14 @@ class SceneStorylineEditor(AbstractSceneElementsEditor):
 
     def refresh(self):
         self._outcomeEditor.refresh()
+
+    def purposeChangedEvent(self):
+        if self._scene.purpose and self._scene.purpose == ScenePurposeType.Story:
+            self._wdgHeader.setVisible(True)
+            self._headerLine.setVisible(True)
+        else:
+            self._wdgHeader.setHidden(True)
+            self._headerLine.setHidden(True)
 
     # def _plotSelected(self, plotElement: PlotSceneElementEditor):
     #     insert_after(self._wdgElements, self._wdgAddNewPlotParent, reference=plotElement)

--- a/src/main/python/plotlyst/view/widget/scene/editor.py
+++ b/src/main/python/plotlyst/view/widget/scene/editor.py
@@ -47,7 +47,7 @@ from src.main.python.plotlyst.view.layout import group
 from src.main.python.plotlyst.view.style.base import apply_white_menu
 from src.main.python.plotlyst.view.widget.characters import CharacterSelectorButton
 from src.main.python.plotlyst.view.widget.display import Icon
-from src.main.python.plotlyst.view.widget.input import RemovalButton
+from src.main.python.plotlyst.view.widget.input import RemovalButton, AutoAdjustableLineEdit
 from src.main.python.plotlyst.view.widget.scene.agency import SceneAgendaEmotionEditor, SceneAgendaMotivationEditor, \
     SceneAgendaConflictEditor
 from src.main.python.plotlyst.view.widget.scene.plot import ScenePlotSelectorButton, ScenePlotValueEditor, \
@@ -656,8 +656,7 @@ class SceneOutcomeEditor(QWidget):
 
         self._icon = push_btn(IconRegistry.disaster_icon('lightgrey', 'lightgrey'), transparent_=True)
         self._icon.setIconSize(QSize(28, 28))
-        self._opacityFilter = OpacityEventFilter(self._icon, leaveOpacity=0.8)
-        self._icon.installEventFilter(self._opacityFilter)
+        self._icon.installEventFilter(OpacityEventFilter(self._icon, leaveOpacity=0.8))
         self._icon.clicked.connect(self._iconClicked)
 
         self._btnReset = RemovalButton()
@@ -671,6 +670,7 @@ class SceneOutcomeEditor(QWidget):
         self.layout().addWidget(self._icon)
         self.layout().addWidget(self._outcomeSelector)
         self.layout().addWidget(self._btnReset, alignment=Qt.AlignmentFlag.AlignTop)
+        self.layout().addWidget(spacer())
 
         self.reset()
 

--- a/src/main/python/plotlyst/view/widget/scene/editor.py
+++ b/src/main/python/plotlyst/view/widget/scene/editor.py
@@ -645,30 +645,28 @@ class TextBasedSceneElementWidget(SceneElementWidget):
         qtanim.glow(self._textEditor, color=self._colorActive)
 
 
-class OutcomeSceneElementEditor(TextBasedSceneElementWidget):
+class SceneOutcomeEditor(QWidget):
     outcomeChanged = pyqtSignal(SceneOutcome)
 
     def __init__(self, parent=None):
-        super().__init__(StoryElementType.Outcome, parent)
+        super().__init__(parent)
+        self._scene: Optional[Scene] = None
         self._outcomeSelector = SceneOutcomeSelector(autoSelect=False)
-        self.setPlaceholderText('Is there an imminent outcome in this scene?')
+        # self.setPlaceholderText('Is there an imminent outcome in this scene?')
 
-        self._pageEditor.layout().addWidget(self._outcomeSelector, alignment=Qt.AlignmentFlag.AlignCenter)
+        # self._pageEditor.layout().addWidget(self._outcomeSelector, alignment=Qt.AlignmentFlag.AlignCenter)
         self._outcomeSelector.selected.connect(self._outcomeSelected)
 
-    @overrides
-    def setElement(self, element: StoryElement):
-        super().setElement(element)
+    def setScene(self, scene: Scene):
+        self._scene = scene
         if self._scene.outcome:
             self._outcomeSelector.refresh(self._scene.outcome)
             self._updateOutcome()
         else:
             self._outcomeSelector.reset()
-            self._resetTitle()
+            # self._resetTitle()
 
-    @overrides
     def reset(self):
-        super().reset()
         self._resetTitle()
 
     def refresh(self):

--- a/src/main/python/plotlyst/view/widget/scene/structure.py
+++ b/src/main/python/plotlyst/view/widget/scene/structure.py
@@ -496,9 +496,12 @@ class SceneStructureBeatWidget(SceneStructureItemWidget):
     def hasOutcome(self) -> bool:
         return self.beat.type == SceneStructureItemType.CLIMAX
 
-    def setOutcome(self, outcome: SceneOutcome):
-        self.beat.outcome = outcome
-        self._outcome.refresh(outcome)
+    def setOutcome(self, outcome: Optional[SceneOutcome]):
+        if outcome:
+            self.beat.outcome = outcome
+            self._outcome.refresh(outcome)
+        # else:
+        #     self._outcome.reset()
         self._initStyle()
 
     def activate(self):


### PR DESCRIPTION
- [x] outcome editor
- [x] outcome button
  - [x] by default grey
  - [x] when clicked, fade in selectors and btnreset
  - [x] when outcome selected, set icon and text and fade in
  - [x] when clicked (again), reset selectors
  - [x] when outcome is none, reset
- [x] test back and forth with structure
- [x] limit to purpose