### PR TITLE
Move backstory panel to comparison panel, closes #778

### DIFF
--- a/src/main/python/plotlyst/test/view/test_scenes.py
+++ b/src/main/python/plotlyst/test/view/test_scenes.py
@@ -224,8 +224,6 @@ def test_character_distribution_display(qtbot, filled_window: MainWindow):
     assert model.flags(model.index(3, 1)) & Qt.ItemFlag.ItemIsEnabled
     assert model.flags(model.index(4, 1)) & Qt.ItemFlag.ItemIsEnabled
 
-    view.characters_distribution.btnGoals.click()
-
     view.characters_distribution.btnConflicts.click()
     assert not view.characters_distribution.spinAverage.isVisible()
 

--- a/src/main/python/plotlyst/view/characters_view.py
+++ b/src/main/python/plotlyst/view/characters_view.py
@@ -170,6 +170,8 @@ class CharactersView(AbstractNovelView):
             lambda: self._wdgComparison.displayAttribute(CharacterComparisonAttribute.FACULTIES))
         self.ui.btnBigFiveComparison.clicked.connect(
             lambda: self._wdgComparison.displayAttribute(CharacterComparisonAttribute.BIG_FIVE))
+        self.ui.btnBackstoryComparison.clicked.connect(
+            lambda: self._wdgComparison.displayAttribute(CharacterComparisonAttribute.BACKSTORY))
         for btn in self.ui.btnGroupComparison.buttons():
             btn.installEventFilter(OpacityEventFilter(btn, ignoreCheckedButton=True))
 

--- a/src/main/python/plotlyst/view/widget/character/comp.py
+++ b/src/main/python/plotlyst/view/widget/character/comp.py
@@ -54,6 +54,9 @@ class CharacterComparisonAttribute(Enum):
 
 class BaseDisplay:
 
+    def __init__(self):
+        self.repo = RepositoryPersistenceManager.instance()
+
     @abstractmethod
     def refresh(self):
         pass
@@ -92,7 +95,6 @@ class SummaryDisplay(QTextEdit, BaseDisplay):
         self.setMinimumWidth(200)
         self.setTabChangesFocus(True)
 
-        self.repo = RepositoryPersistenceManager.instance()
         self.refresh()
 
         self.textChanged.connect(self._save)
@@ -136,7 +138,6 @@ class FacultiesDisplay(QWidget, BaseDisplay):
         self.setMaximumWidth(300)
         self.setMinimumWidth(250)
 
-        self.repo = RepositoryPersistenceManager.instance()
         self.refresh()
 
     @overrides
@@ -188,6 +189,11 @@ class BackstoryDisplay(CharacterTimelineWidget, BaseDisplay):
         super().__init__(parent)
         self._character = character
         self.setCharacter(self._character)
+
+        self.changed.connect(self._save)
+
+    def _save(self):
+        self.repo.update_character(self._character)
 
 
 class CharacterOverviewWidget(QWidget, EventListener):

--- a/src/main/python/plotlyst/view/widget/character/comp.py
+++ b/src/main/python/plotlyst/view/widget/character/comp.py
@@ -210,14 +210,17 @@ class CharacterOverviewWidget(QWidget, EventListener):
             self._roleIcon.setRole(self._character.role, showText=True)
 
         vbox(self, 0)
-        self.layout().addWidget(self._avatar, alignment=Qt.AlignmentFlag.AlignCenter)
-        self.layout().addWidget(self._roleIcon, alignment=Qt.AlignmentFlag.AlignCenter)
-        self.layout().addWidget(line())
+        self._wdgHeader = QWidget()
+        vbox(self._wdgHeader, 0)
+        self._wdgHeader.layout().addWidget(self._avatar, alignment=Qt.AlignmentFlag.AlignCenter)
+        self._wdgHeader.layout().addWidget(self._roleIcon, alignment=Qt.AlignmentFlag.AlignCenter)
+        self._wdgHeader.layout().addWidget(line())
 
         self._display: Optional[BaseDisplay] = None
         self._displayContainer = QWidget()
         hbox(self._displayContainer, 0, 0)
 
+        self.layout().addWidget(self._wdgHeader)
         self.layout().addWidget(self._displayContainer)
         self.layout().addWidget(vspacer())
 
@@ -236,6 +239,8 @@ class CharacterOverviewWidget(QWidget, EventListener):
             gc(self._display)
             self._display = None
 
+        self._wdgHeader.setVisible(True)
+
         if attribute == CharacterComparisonAttribute.BIG_FIVE:
             self._display = BigFiveDisplay(self._character)
             self._displayContainer.layout().addWidget(self._display)
@@ -246,6 +251,7 @@ class CharacterOverviewWidget(QWidget, EventListener):
             self._display = FacultiesDisplay(self._character)
             self._displayContainer.layout().addWidget(self._display)
         elif attribute == CharacterComparisonAttribute.BACKSTORY:
+            self._wdgHeader.setHidden(True)
             self._display = BackstoryDisplay(self._character)
             self._displayContainer.layout().addWidget(self._display)
 

--- a/src/main/python/plotlyst/view/widget/character/comp.py
+++ b/src/main/python/plotlyst/view/widget/character/comp.py
@@ -242,7 +242,6 @@ class CharacterOverviewWidget(QWidget, EventListener):
         elif attribute == CharacterComparisonAttribute.BACKSTORY:
             self._display = BackstoryDisplay(self._character)
             self._displayContainer.layout().addWidget(self._display)
-            # apply_bg_image(self.ui.scrollAreaBackstoryContent, resource_registry.cover1)
 
 
 class LayoutType(Enum):
@@ -291,6 +290,9 @@ class CharacterComparisonWidget(QWidget):
             wdg.display(self._currentDisplay)
 
     def displayAttribute(self, attribute: CharacterComparisonAttribute):
+        if attribute == CharacterComparisonAttribute.BACKSTORY:
+            self.updateLayout(LayoutType.HORIZONTAL)
+
         for wdg in self._characters.values():
             wdg.display(attribute)
 

--- a/src/main/python/plotlyst/view/widget/character/comp.py
+++ b/src/main/python/plotlyst/view/widget/character/comp.py
@@ -242,6 +242,7 @@ class CharacterOverviewWidget(QWidget, EventListener):
         elif attribute == CharacterComparisonAttribute.BACKSTORY:
             self._display = BackstoryDisplay(self._character)
             self._displayContainer.layout().addWidget(self._display)
+            # apply_bg_image(self.ui.scrollAreaBackstoryContent, resource_registry.cover1)
 
 
 class LayoutType(Enum):

--- a/src/main/python/plotlyst/view/widget/character/comp.py
+++ b/src/main/python/plotlyst/view/widget/character/comp.py
@@ -39,6 +39,7 @@ from src.main.python.plotlyst.view.common import fade_out_and_gc
 from src.main.python.plotlyst.view.icons import set_avatar, avatars
 from src.main.python.plotlyst.view.widget.big_five import BigFiveChart, dimension_from
 from src.main.python.plotlyst.view.widget.button import EyeToggle
+from src.main.python.plotlyst.view.widget.characters import CharacterTimelineWidget
 from src.main.python.plotlyst.view.widget.display import RoleIcon, ChartView
 from src.main.python.plotlyst.view.widget.template.impl import BarTemplateFieldWidget
 from src.main.python.plotlyst.view.widget.tree import TreeView, ContainerNode
@@ -48,6 +49,7 @@ class CharacterComparisonAttribute(Enum):
     SUMMARY = 0
     BIG_FIVE = 1
     FACULTIES = 2
+    BACKSTORY = 3
 
 
 class BaseDisplay:
@@ -181,6 +183,13 @@ class FacultiesDisplay(QWidget, BaseDisplay):
             self._display.save()
 
 
+class BackstoryDisplay(CharacterTimelineWidget, BaseDisplay):
+    def __init__(self, character: Character, parent=None):
+        super().__init__(parent)
+        self._character = character
+        self.setCharacter(self._character)
+
+
 class CharacterOverviewWidget(QWidget, EventListener):
     def __init__(self, novel: Novel, character: Character, parent=None):
         super().__init__(parent)
@@ -229,6 +238,9 @@ class CharacterOverviewWidget(QWidget, EventListener):
             self._displayContainer.layout().addWidget(self._display, alignment=Qt.AlignmentFlag.AlignCenter)
         elif attribute == CharacterComparisonAttribute.FACULTIES:
             self._display = FacultiesDisplay(self._character)
+            self._displayContainer.layout().addWidget(self._display)
+        elif attribute == CharacterComparisonAttribute.BACKSTORY:
+            self._display = BackstoryDisplay(self._character)
             self._displayContainer.layout().addWidget(self._display)
 
 

--- a/ui/characters_view.ui
+++ b/ui/characters_view.ui
@@ -426,7 +426,7 @@
        <item>
         <widget class="QStackedWidget" name="stackCharacters">
          <property name="currentIndex">
-          <number>1</number>
+          <number>3</number>
          </property>
          <widget class="QWidget" name="pageTableView">
           <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -622,98 +622,112 @@
               </spacer>
              </item>
              <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_9">
-               <item>
-                <widget class="QToolButton" name="btnHorizontalComparison">
-                 <property name="enabled">
-                  <bool>true</bool>
-                 </property>
-                 <property name="cursor">
-                  <cursorShape>PointingHandCursor</cursorShape>
-                 </property>
-                 <property name="toolTip">
-                  <string>Vertical layout</string>
-                 </property>
-                 <property name="text">
-                  <string/>
-                 </property>
-                 <property name="iconSize">
-                  <size>
-                   <width>14</width>
-                   <height>14</height>
-                  </size>
-                 </property>
-                 <property name="checkable">
-                  <bool>true</bool>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                 <attribute name="buttonGroup">
-                  <string notr="true">btnGroupComparisonView</string>
-                 </attribute>
-                </widget>
-               </item>
-               <item>
-                <widget class="QToolButton" name="btnVerticalComparison">
-                 <property name="enabled">
-                  <bool>false</bool>
-                 </property>
-                 <property name="cursor">
-                  <cursorShape>PointingHandCursor</cursorShape>
-                 </property>
-                 <property name="toolTip">
-                  <string>Horizontal layout</string>
-                 </property>
-                 <property name="text">
-                  <string/>
-                 </property>
-                 <property name="iconSize">
-                  <size>
-                   <width>14</width>
-                   <height>14</height>
-                  </size>
-                 </property>
-                 <property name="checkable">
-                  <bool>true</bool>
-                 </property>
-                 <property name="checked">
-                  <bool>false</bool>
-                 </property>
-                 <attribute name="buttonGroup">
-                  <string notr="true">btnGroupComparisonView</string>
-                 </attribute>
-                </widget>
-               </item>
-               <item>
-                <widget class="QToolButton" name="btnGridComparison">
-                 <property name="enabled">
-                  <bool>true</bool>
-                 </property>
-                 <property name="cursor">
-                  <cursorShape>PointingHandCursor</cursorShape>
-                 </property>
-                 <property name="toolTip">
-                  <string>Table layout</string>
-                 </property>
-                 <property name="text">
-                  <string/>
-                 </property>
-                 <property name="iconSize">
-                  <size>
-                   <width>14</width>
-                   <height>14</height>
-                  </size>
-                 </property>
-                 <property name="checkable">
-                  <bool>true</bool>
-                 </property>
-                 <attribute name="buttonGroup">
-                  <string notr="true">btnGroupComparisonView</string>
-                 </attribute>
-                </widget>
-               </item>
-              </layout>
+              <widget class="QWidget" name="wdgComparisonLayout" native="true">
+               <layout class="QHBoxLayout" name="horizontalLayout_9">
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QToolButton" name="btnHorizontalComparison">
+                  <property name="enabled">
+                   <bool>true</bool>
+                  </property>
+                  <property name="cursor">
+                   <cursorShape>PointingHandCursor</cursorShape>
+                  </property>
+                  <property name="toolTip">
+                   <string>Vertical layout</string>
+                  </property>
+                  <property name="text">
+                   <string/>
+                  </property>
+                  <property name="iconSize">
+                   <size>
+                    <width>14</width>
+                    <height>14</height>
+                   </size>
+                  </property>
+                  <property name="checkable">
+                   <bool>true</bool>
+                  </property>
+                  <property name="checked">
+                   <bool>true</bool>
+                  </property>
+                  <attribute name="buttonGroup">
+                   <string notr="true">btnGroupComparisonView</string>
+                  </attribute>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QToolButton" name="btnVerticalComparison">
+                  <property name="enabled">
+                   <bool>false</bool>
+                  </property>
+                  <property name="cursor">
+                   <cursorShape>PointingHandCursor</cursorShape>
+                  </property>
+                  <property name="toolTip">
+                   <string>Horizontal layout</string>
+                  </property>
+                  <property name="text">
+                   <string/>
+                  </property>
+                  <property name="iconSize">
+                   <size>
+                    <width>14</width>
+                    <height>14</height>
+                   </size>
+                  </property>
+                  <property name="checkable">
+                   <bool>true</bool>
+                  </property>
+                  <property name="checked">
+                   <bool>false</bool>
+                  </property>
+                  <attribute name="buttonGroup">
+                   <string notr="true">btnGroupComparisonView</string>
+                  </attribute>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QToolButton" name="btnGridComparison">
+                  <property name="enabled">
+                   <bool>true</bool>
+                  </property>
+                  <property name="cursor">
+                   <cursorShape>PointingHandCursor</cursorShape>
+                  </property>
+                  <property name="toolTip">
+                   <string>Table layout</string>
+                  </property>
+                  <property name="text">
+                   <string/>
+                  </property>
+                  <property name="iconSize">
+                   <size>
+                    <width>14</width>
+                    <height>14</height>
+                   </size>
+                  </property>
+                  <property name="checkable">
+                   <bool>true</bool>
+                  </property>
+                  <attribute name="buttonGroup">
+                   <string notr="true">btnGroupComparisonView</string>
+                  </attribute>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
              </item>
             </layout>
            </item>
@@ -952,10 +966,13 @@
                     <x>0</x>
                     <y>0</y>
                     <width>873</width>
-                    <height>520</height>
+                    <height>521</height>
                    </rect>
                   </property>
                   <property name="relaxed-white-bg" stdset="0">
+                   <bool>true</bool>
+                  </property>
+                  <property name="bg-image" stdset="0">
                    <bool>true</bool>
                   </property>
                   <layout class="QVBoxLayout" name="verticalLayout_8">

--- a/ui/characters_view.ui
+++ b/ui/characters_view.ui
@@ -451,7 +451,7 @@
        <item>
         <widget class="QStackedWidget" name="stackCharacters">
          <property name="currentIndex">
-          <number>2</number>
+          <number>4</number>
          </property>
          <widget class="QWidget" name="pageTableView">
           <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -555,8 +555,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>98</width>
-                <height>28</height>
+                <width>84</width>
+                <height>16</height>
                </rect>
               </property>
               <property name="bg-image" stdset="0">
@@ -939,6 +939,34 @@
                        </property>
                        <property name="text">
                         <string>Faculties</string>
+                       </property>
+                       <property name="checkable">
+                        <bool>true</bool>
+                       </property>
+                       <property name="checked">
+                        <bool>false</bool>
+                       </property>
+                       <property name="transparent-rounded-bg-on-hover" stdset="0">
+                        <bool>true</bool>
+                       </property>
+                       <property name="secondary-selector" stdset="0">
+                        <bool>true</bool>
+                       </property>
+                       <attribute name="buttonGroup">
+                        <string notr="true">btnGroupComparison</string>
+                       </attribute>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QPushButton" name="btnBackstoryComparison">
+                       <property name="cursor">
+                        <cursorShape>PointingHandCursor</cursorShape>
+                       </property>
+                       <property name="toolTip">
+                        <string>Compare Big Five traits</string>
+                       </property>
+                       <property name="text">
+                        <string>Backstory</string>
                        </property>
                        <property name="checkable">
                         <bool>true</bool>

--- a/ui/characters_view.ui
+++ b/ui/characters_view.ui
@@ -160,12 +160,12 @@
            </widget>
           </item>
           <item>
-           <widget class="QToolButton" name="btnBackstoryView">
+           <widget class="QToolButton" name="btnComparison">
             <property name="cursor">
              <cursorShape>PointingHandCursor</cursorShape>
             </property>
             <property name="toolTip">
-             <string>Backstory view</string>
+             <string>Comparison view</string>
             </property>
             <property name="text">
              <string/>
@@ -213,31 +213,6 @@
            </widget>
           </item>
           <item>
-           <widget class="QToolButton" name="btnComparison">
-            <property name="cursor">
-             <cursorShape>PointingHandCursor</cursorShape>
-            </property>
-            <property name="toolTip">
-             <string>Comparison view</string>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-            <property name="shortcut">
-             <string>5</string>
-            </property>
-            <property name="checkable">
-             <bool>true</bool>
-            </property>
-            <property name="base" stdset="0">
-             <bool>true</bool>
-            </property>
-            <attribute name="buttonGroup">
-             <string notr="true">btnGroupViews</string>
-            </attribute>
-           </widget>
-          </item>
-          <item>
            <widget class="Line" name="line_2">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -256,7 +231,7 @@
              <string/>
             </property>
             <property name="shortcut">
-             <string>6</string>
+             <string>5</string>
             </property>
             <property name="checkable">
              <bool>true</bool>
@@ -451,7 +426,7 @@
        <item>
         <widget class="QStackedWidget" name="stackCharacters">
          <property name="currentIndex">
-          <number>4</number>
+          <number>1</number>
          </property>
          <widget class="QWidget" name="pageTableView">
           <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -508,78 +483,6 @@
              <attribute name="verticalHeaderDefaultSectionSize">
               <number>33</number>
              </attribute>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-         <widget class="QWidget" name="pageBackstory">
-          <layout class="QVBoxLayout" name="verticalLayout_2">
-           <property name="spacing">
-            <number>3</number>
-           </property>
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>2</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
-            <number>2</number>
-           </property>
-           <item alignment="Qt::AlignTop">
-            <widget class="CharacterSelectorButtons" name="wdgCharacterSelector" native="true">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>0</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QScrollArea" name="scrollArea_2">
-             <property name="widgetResizable">
-              <bool>true</bool>
-             </property>
-             <widget class="QWidget" name="scrollAreaBackstoryContent">
-              <property name="geometry">
-               <rect>
-                <x>0</x>
-                <y>0</y>
-                <width>84</width>
-                <height>16</height>
-               </rect>
-              </property>
-              <property name="bg-image" stdset="0">
-               <bool>true</bool>
-              </property>
-              <layout class="QHBoxLayout" name="horizontalLayout_4">
-               <property name="spacing">
-                <number>3</number>
-               </property>
-               <property name="leftMargin">
-                <number>2</number>
-               </property>
-               <property name="topMargin">
-                <number>2</number>
-               </property>
-               <property name="rightMargin">
-                <number>2</number>
-               </property>
-               <property name="bottomMargin">
-                <number>2</number>
-               </property>
-              </layout>
-             </widget>
             </widget>
            </item>
           </layout>
@@ -1191,12 +1094,6 @@
    <class>CardsView</class>
    <extends>QFrame</extends>
    <header>src.main.python.plotlyst.view.widget.cards</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>CharacterSelectorButtons</class>
-   <extends>QWidget</extends>
-   <header>src.main.python.plotlyst.view.widget.characters</header>
    <container>1</container>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
- [x] rearrange panels and shortcuts
- [x] backstory icon
- [x] faculties icon
- [x] remove old backstory panel
- [x] hide layout toggle
- [x] bg image
- [x] hide top avatar in wdg
- [x] save