### PR TITLE
Track general scene and storyline progress

### DIFF
--- a/src/main/python/plotlyst/core/client.py
+++ b/src/main/python/plotlyst/core/client.py
@@ -177,6 +177,7 @@ class SceneInfo:
     structure: List[SceneStructureItem] = field(default_factory=list)
     questions: List[SceneReaderQuestion] = field(default_factory=list)
     info: List[SceneReaderInformation] = field(default_factory=list)
+    progress: int = 0
 
 
 @dataclass
@@ -560,7 +561,8 @@ class JsonClient:
                               comments=info.comments, tag_references=info.tag_references,
                               document=info.document, manuscript=info.manuscript, drive=info.drive,
                               purpose=info.purpose, outcome=info.outcome, story_elements=info.story_elements,
-                              structure=info.structure, questions=info.questions, info=info.info)
+                              structure=info.structure, questions=info.questions, info=info.info,
+                              progress=info.progress)
                 scenes.append(scene)
 
         tag_types = novel_info.tag_types
@@ -678,7 +680,7 @@ class JsonClient:
                          tag_references=scene.tag_references, document=scene.document, manuscript=scene.manuscript,
                          drive=scene.drive, purpose=scene.purpose, outcome=scene.outcome,
                          story_elements=scene.story_elements,
-                         structure=scene.structure, questions=scene.questions, info=scene.info)
+                         structure=scene.structure, questions=scene.questions, info=scene.info, progress=scene.progress)
         self.__persist_info(self.scenes_dir(novel), info)
 
     def _persist_diagram(self, novel: Novel, diagram: Diagram):

--- a/src/main/python/plotlyst/core/domain.py
+++ b/src/main/python/plotlyst/core/domain.py
@@ -1624,6 +1624,7 @@ class Scene:
     structure: List[SceneStructureItem] = field(default_factory=list)
     questions: List[SceneReaderQuestion] = field(default_factory=list)
     info: List[SceneReaderInformation] = field(default_factory=list)
+    progress: int = 0
 
     def beat(self, novel: 'Novel') -> Optional[StoryBeat]:
         structure = novel.active_story_structure

--- a/src/main/python/plotlyst/core/domain.py
+++ b/src/main/python/plotlyst/core/domain.py
@@ -1244,6 +1244,7 @@ class ScenePlotValueCharge:
 @dataclass
 class ScenePlotReferenceData:
     comment: str = field(default='', metadata=config(exclude=exclude_if_empty))
+    charge: int = 0
     values: List[ScenePlotValueCharge] = field(default_factory=list)
 
 

--- a/src/main/python/plotlyst/view/icons.py
+++ b/src/main/python/plotlyst/view/icons.py
@@ -625,6 +625,18 @@ class IconRegistry:
             return IconRegistry.from_name('mdi.chevron-triple-down', '#9d0208')
 
     @staticmethod
+    def trade_off_charge_icon(charge: int = 1) -> QIcon:
+        color = '#832161'
+        if charge == 0:
+            return IconRegistry.from_name('mdi.wave', color)
+        elif charge == 1:
+            return IconRegistry.from_name('mdi.chevron-right', color)
+        elif charge == 2:
+            return IconRegistry.from_name('mdi.chevron-double-right', color)
+        elif charge >= 3:
+            return IconRegistry.from_name('mdi.chevron-triple-right', color)
+
+    @staticmethod
     def male_gender_icon(color: str = 'black') -> QIcon:
         return IconRegistry.from_name('mdi.gender-male', color=color, color_on='#067bc2')
 

--- a/src/main/python/plotlyst/view/icons.py
+++ b/src/main/python/plotlyst/view/icons.py
@@ -612,11 +612,11 @@ class IconRegistry:
         if charge == 0:
             return IconRegistry.from_name('mdi.wave', 'grey')
         elif charge == 1:
-            return IconRegistry.from_name('mdi.chevron-up', '#2d6a4f')
+            return IconRegistry.from_name('mdi.chevron-up', '#52b788')
         elif charge == 2:
             return IconRegistry.from_name('mdi.chevron-double-up', '#40916c')
         elif charge >= 3:
-            return IconRegistry.from_name('mdi.chevron-triple-up', '#52b788')
+            return IconRegistry.from_name('mdi.chevron-triple-up', '#2d6a4f')
         elif charge == -1:
             return IconRegistry.from_name('mdi.chevron-down', '#dc2f02')
         elif charge == -2:

--- a/src/main/python/plotlyst/view/scene_editor.py
+++ b/src/main/python/plotlyst/view/scene_editor.py
@@ -50,7 +50,7 @@ from plotlyst.view.icons import IconRegistry
 from plotlyst.view.widget.characters import CharacterSelectorMenu
 from plotlyst.view.widget.labels import CharacterLabel
 from plotlyst.view.widget.scene.editor import ScenePurposeSelectorWidget, ScenePurposeTypeButton, \
-    SceneStorylineEditor, SceneAgendaEditor, SceneElementWidget
+    SceneStorylineEditor, SceneAgendaEditor, SceneElementWidget, SceneProgressEditor
 from plotlyst.view.widget.scene.plot import ScenePlotLabels, \
     ScenePlotSelectorMenu
 from plotlyst.view.widget.scene.reader_drive import ReaderCuriosityEditor, ReaderInformationEditor
@@ -113,6 +113,9 @@ class SceneEditor(QObject, EventListener):
         self._povMenu.selected.connect(self._pov_changed)
         self.ui.wdgPov.btnAvatar.setText('POV')
         self.ui.wdgPov.setFixedSize(170, 170)
+
+        self._progressEditor = SceneProgressEditor()
+        self.ui.wdgTop.layout().addWidget(self._progressEditor)
 
         self.ui.textNotes.setTitleVisible(False)
         self.ui.textNotes.setPlaceholderText("Scene notes")
@@ -221,6 +224,7 @@ class SceneEditor(QObject, EventListener):
         self._agencyEditor.setScene(self.scene)
         self._curiosityEditor.setScene(self.scene)
         self._informationEditor.setScene(self.scene)
+        self._progressEditor.setScene(self.scene)
 
         self.ui.lineTitle.setText(self.scene.title)
         self.ui.textSynopsis.setText(self.scene.synopsis)

--- a/src/main/python/plotlyst/view/scene_editor.py
+++ b/src/main/python/plotlyst/view/scene_editor.py
@@ -340,6 +340,7 @@ class SceneEditor(QObject, EventListener):
     def _add_plot_ref(self, plotRef: ScenePlotReference) -> ScenePlotLabels:
         labels = ScenePlotLabels(plotRef)
         labels.reset.connect(partial(self._storyline_removed, labels, plotRef))
+        labels.generalProgressCharged.connect(self._progressEditor.refresh)
         self.ui.wdgStorylines.layout().addWidget(labels)
         self._btnPlotSelector.setText('')
 

--- a/src/main/python/plotlyst/view/scene_editor.py
+++ b/src/main/python/plotlyst/view/scene_editor.py
@@ -324,6 +324,7 @@ class SceneEditor(QObject, EventListener):
     def _storyline_removed(self, labels: ScenePlotLabels, plotRef: ScenePlotReference):
         fade_out_and_gc(self.ui.wdgStorylines.layout(), labels)
         self.scene.plot_values.remove(plotRef)
+        self._progressEditor.refresh()
 
     def _storyline_linked(self, element: SceneElementWidget, storyline: Plot):
         if next((x for x in self.scene.plot_values if x.plot.id == storyline.id), None) is None:

--- a/src/main/python/plotlyst/view/widget/scene/editor.py
+++ b/src/main/python/plotlyst/view/widget/scene/editor.py
@@ -1789,3 +1789,8 @@ class SceneAgendaEditor(AbstractSceneElementsEditor, EventListener):
         self._emotionEditor.setVisible(elements_visible and self._novel.prefs.toggled(NovelSetting.Track_emotion))
         self._motivationEditor.setVisible(elements_visible and self._novel.prefs.toggled(NovelSetting.Track_motivation))
         self._conflictEditor.setVisible(elements_visible and self._novel.prefs.toggled(NovelSetting.Track_conflict))
+
+
+class SceneProgressEditor(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)

--- a/src/main/python/plotlyst/view/widget/scene/editor.py
+++ b/src/main/python/plotlyst/view/widget/scene/editor.py
@@ -1796,10 +1796,21 @@ class SceneProgressEditor(ProgressEditor):
     def __init__(self, parent=None):
         super().__init__(parent)
         self._scene: Optional[Scene] = None
+        self.btnLock.setToolTip('Scene progression is calculated from the associated storylines')
 
     def setScene(self, scene: Scene):
         self._scene = scene
         self.refresh()
+
+    @overrides
+    def refresh(self):
+        self._chargeEnabled = True
+        for ref in self._scene.plot_values:
+            if ref.data.charge:
+                self._chargeEnabled = False
+                break
+
+        super().refresh()
 
     @overrides
     def _changeCharge(self, charge: int):

--- a/src/main/python/plotlyst/view/widget/scene/editor.py
+++ b/src/main/python/plotlyst/view/widget/scene/editor.py
@@ -1794,3 +1794,67 @@ class SceneAgendaEditor(AbstractSceneElementsEditor, EventListener):
 class SceneProgressEditor(QWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
+        self._scene: Optional[Scene] = None
+        hbox(self)
+
+        self._idleIcon = IconRegistry.from_name('mdi.chevron-double-up', 'lightgrey')
+        self.btnProgress = tool_btn(self._idleIcon, transparent_=True, pointy_=False)
+        self.btnProgress.setIconSize(QSize(76, 76))
+
+        self.posCharge = tool_btn(IconRegistry.plus_circle_icon('grey'), transparent_=True)
+        decr_icon(self.posCharge, 4)
+        self.posCharge.clicked.connect(lambda: self._changeCharge(1))
+        retain_when_hidden(self.posCharge)
+        self.negCharge = tool_btn(IconRegistry.minus_icon('grey'), transparent_=True)
+        decr_icon(self.negCharge, 4)
+        self.negCharge.clicked.connect(lambda: self._changeCharge(-1))
+        retain_when_hidden(self.negCharge)
+
+        self.posCharge.setHidden(True)
+        self.negCharge.setHidden(True)
+
+        self.wdgSize = QWidget()
+        vbox(self.wdgSize, 0, 0)
+        self.wdgSize.layout().addWidget(self.posCharge)
+        self.wdgSize.layout().addWidget(self.negCharge)
+
+        self.layout().addWidget(self.btnProgress)
+        self.layout().addWidget(self.wdgSize, alignment=Qt.AlignmentFlag.AlignVCenter)
+
+    @overrides
+    def enterEvent(self, event: QEnterEvent) -> None:
+        self.posCharge.setVisible(True)
+        self.negCharge.setVisible(True)
+
+    @overrides
+    def leaveEvent(self, event: QEvent) -> None:
+        self.posCharge.setHidden(True)
+        self.negCharge.setHidden(True)
+
+    def setScene(self, scene: Scene):
+        self._scene = scene
+        self.refresh()
+
+    def refresh(self):
+        if self._scene.progress == 0:
+            self.btnProgress.setIcon(self._idleIcon)
+        else:
+            self.btnProgress.setIcon(IconRegistry.charge_icon(self._scene.progress))
+
+        self._updateButtons()
+
+    def _changeCharge(self, charge: int):
+        if not self._scene:
+            return
+        self._scene.progress += charge
+        self.refresh()
+
+    def _updateButtons(self):
+        self.posCharge.setEnabled(True)
+        self.negCharge.setEnabled(True)
+
+        if self._scene:
+            if self._scene.progress == 3:
+                self.posCharge.setDisabled(True)
+            elif self._scene.progress == -3:
+                self.negCharge.setDisabled(True)

--- a/src/main/python/plotlyst/view/widget/scene/editor.py
+++ b/src/main/python/plotlyst/view/widget/scene/editor.py
@@ -1819,9 +1819,6 @@ class SceneProgressEditor(ProgressEditor):
                 else:
                     negCharge = min(negCharge, ref.data.charge)
 
-        # if posCharge > abs(negCharge):
-        #     self._charge = posCharge
-        #     self._altCharge = negCharge
         if abs(negCharge) > posCharge:
             self._charge = negCharge
             self._altCharge = posCharge

--- a/src/main/python/plotlyst/view/widget/scene/plot.py
+++ b/src/main/python/plotlyst/view/widget/scene/plot.py
@@ -23,7 +23,7 @@ from typing import Optional, Dict
 
 import qtanim
 from PyQt6.QtCore import Qt, pyqtSignal, QSize, QEvent
-from PyQt6.QtGui import QColor, QMouseEvent, QEnterEvent
+from PyQt6.QtGui import QColor, QMouseEvent, QEnterEvent, QResizeEvent
 from PyQt6.QtWidgets import QWidget, QToolButton, QGraphicsDropShadowEffect, QTextEdit
 from overrides import overrides
 from qthandy import vbox, hbox, transparent, retain_when_hidden, spacer, sp, decr_icon, line, vline, \
@@ -90,6 +90,9 @@ class ProgressEditor(QWidget):
         apply_button_palette_color(self.btnProgress, 'grey')
         self.btnProgress.setIconSize(QSize(76, 76))
 
+        self.btnProgressAlt = tool_btn(self._idleIcon, transparent_=True, pointy_=False, parent=self.btnProgress)
+        self.btnProgressAlt.setHidden(True)
+
         self.posCharge = tool_btn(IconRegistry.plus_circle_icon('grey'), transparent_=True)
         decr_icon(self.posCharge, 4)
         self.posCharge.clicked.connect(lambda: self._changeCharge(1))
@@ -125,6 +128,11 @@ class ProgressEditor(QWidget):
         self.wdgSize.setHidden(True)
         self.btnLock.setHidden(True)
 
+    @overrides
+    def resizeEvent(self, event: QResizeEvent) -> None:
+        self.btnProgressAlt.setGeometry(self.btnProgress.size().width() - 20, self.btnProgress.size().height() - 20, 20,
+                                        20)
+
     def refresh(self):
         if self.charge() == 0:
             self.btnProgress.setIcon(self._idleIcon)
@@ -133,11 +141,20 @@ class ProgressEditor(QWidget):
             self.btnProgress.setIcon(IconRegistry.charge_icon(self.charge()))
             self.btnProgress.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
 
+        if self.altCharge() == 0:
+            self.btnProgressAlt.setHidden(True)
+        else:
+            self.btnProgressAlt.setVisible(True)
+            self.btnProgressAlt.setIcon(IconRegistry.charge_icon(self.altCharge()))
+
         self._updateButtons()
 
     @abstractmethod
     def charge(self) -> int:
         pass
+
+    def altCharge(self) -> int:
+        return 0
 
     @abstractmethod
     def _changeCharge(self, charge: int):

--- a/src/main/python/plotlyst/view/widget/scene/plot.py
+++ b/src/main/python/plotlyst/view/widget/scene/plot.py
@@ -86,6 +86,7 @@ class ProgressEditor(QWidget):
         self._chargeEnabled: bool = True
         self.btnProgress = tool_btn(self._idleIcon, transparent_=True, pointy_=False)
         self.btnProgress.setText('Progress')
+        self.btnProgress.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextUnderIcon)
         italic(self.btnProgress)
         apply_button_palette_color(self.btnProgress, 'grey')
         self.btnProgress.setIconSize(QSize(76, 76))
@@ -130,16 +131,14 @@ class ProgressEditor(QWidget):
 
     @overrides
     def resizeEvent(self, event: QResizeEvent) -> None:
-        self.btnProgressAlt.setGeometry(self.btnProgress.size().width() - 20, self.btnProgress.size().height() - 20, 20,
+        self.btnProgressAlt.setGeometry(self.btnProgress.size().width() - 20, self.btnProgress.size().height() - 40, 20,
                                         20)
 
     def refresh(self):
         if self.charge() == 0:
             self.btnProgress.setIcon(self._idleIcon)
-            self.btnProgress.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextUnderIcon)
         else:
             self.btnProgress.setIcon(IconRegistry.charge_icon(self.charge()))
-            self.btnProgress.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
 
         if self.altCharge() == 0:
             self.btnProgressAlt.setHidden(True)

--- a/src/main/python/plotlyst/view/widget/scene/plot.py
+++ b/src/main/python/plotlyst/view/widget/scene/plot.py
@@ -27,7 +27,7 @@ from PyQt6.QtGui import QColor, QMouseEvent, QEnterEvent
 from PyQt6.QtWidgets import QWidget, QToolButton, QGraphicsDropShadowEffect, QTextEdit
 from overrides import overrides
 from qthandy import vbox, hbox, transparent, retain_when_hidden, spacer, sp, decr_icon, line, vline, \
-    margins
+    margins, italic
 from qthandy.filter import OpacityEventFilter, VisibilityToggleEventFilter, InstantTooltipEventFilter
 from qtmenu import MenuWidget
 
@@ -36,6 +36,7 @@ from plotlyst.core.domain import Novel, Scene, ScenePlotReference, PlotValue, Sc
 from plotlyst.view.common import action, tool_btn, wrap
 from plotlyst.view.icons import IconRegistry
 from plotlyst.view.style.base import apply_white_menu
+from plotlyst.view.style.button import apply_button_palette_color
 from plotlyst.view.widget.button import SecondaryActionToolButton
 from plotlyst.view.widget.display import Icon
 from plotlyst.view.widget.input import RemovalButton
@@ -84,6 +85,9 @@ class ProgressEditor(QWidget):
         self._idleIcon = IconRegistry.from_name('mdi.chevron-double-up', 'lightgrey')
         self._chargeEnabled: bool = True
         self.btnProgress = tool_btn(self._idleIcon, transparent_=True, pointy_=False)
+        self.btnProgress.setText('Progress')
+        italic(self.btnProgress)
+        apply_button_palette_color(self.btnProgress, 'grey')
         self.btnProgress.setIconSize(QSize(76, 76))
 
         self.posCharge = tool_btn(IconRegistry.plus_circle_icon('grey'), transparent_=True)
@@ -124,8 +128,10 @@ class ProgressEditor(QWidget):
     def refresh(self):
         if self.charge() == 0:
             self.btnProgress.setIcon(self._idleIcon)
+            self.btnProgress.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextUnderIcon)
         else:
             self.btnProgress.setIcon(IconRegistry.charge_icon(self.charge()))
+            self.btnProgress.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
 
         self._updateButtons()
 

--- a/src/main/python/plotlyst/view/widget/scene/plot.py
+++ b/src/main/python/plotlyst/view/widget/scene/plot.py
@@ -17,12 +17,13 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
+from abc import abstractmethod
 from functools import partial
 from typing import Optional, Dict
 
 import qtanim
-from PyQt6.QtCore import Qt, pyqtSignal
-from PyQt6.QtGui import QColor, QMouseEvent
+from PyQt6.QtCore import Qt, pyqtSignal, QSize, QEvent
+from PyQt6.QtGui import QColor, QMouseEvent, QEnterEvent
 from PyQt6.QtWidgets import QWidget, QToolButton, QGraphicsDropShadowEffect, QTextEdit
 from overrides import overrides
 from qthandy import vbox, hbox, transparent, retain_when_hidden, spacer, sp, decr_icon, line, vline, \
@@ -32,7 +33,7 @@ from qtmenu import MenuWidget
 
 from plotlyst.core.domain import Novel, Scene, ScenePlotReference, PlotValue, ScenePlotValueCharge, \
     Plot, PlotType
-from plotlyst.view.common import action, tool_btn
+from plotlyst.view.common import action, tool_btn, wrap
 from plotlyst.view.icons import IconRegistry
 from plotlyst.view.style.base import apply_white_menu
 from plotlyst.view.widget.button import SecondaryActionToolButton
@@ -72,6 +73,100 @@ class PlotValuesDisplay(QWidget):
             effect.setOffset(5 * abs(charge.charge), 0)
             effect.setBlurRadius(25)
             lbl.setGraphicsEffect(effect)
+
+
+class ProgressEditor(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        hbox(self, spacing=0)
+
+        self._idleIcon = IconRegistry.from_name('mdi.chevron-double-up', 'lightgrey')
+        self.btnProgress = tool_btn(self._idleIcon, transparent_=True, pointy_=False)
+        self.btnProgress.setIconSize(QSize(76, 76))
+
+        self.posCharge = tool_btn(IconRegistry.plus_circle_icon('grey'), transparent_=True)
+        decr_icon(self.posCharge, 4)
+        self.posCharge.clicked.connect(lambda: self._changeCharge(1))
+        retain_when_hidden(self.posCharge)
+        self.negCharge = tool_btn(IconRegistry.minus_icon('grey'), transparent_=True)
+        decr_icon(self.negCharge, 4)
+        self.negCharge.clicked.connect(lambda: self._changeCharge(-1))
+        retain_when_hidden(self.negCharge)
+
+        self.posCharge.setHidden(True)
+        self.negCharge.setHidden(True)
+
+        self.wdgSize = QWidget()
+        vbox(self.wdgSize, 0, 0)
+        self.wdgSize.layout().addWidget(self.posCharge)
+        self.wdgSize.layout().addWidget(self.negCharge)
+
+        self.layout().addWidget(self.btnProgress)
+        self.layout().addWidget(self.wdgSize, alignment=Qt.AlignmentFlag.AlignVCenter)
+
+    @overrides
+    def enterEvent(self, event: QEnterEvent) -> None:
+        self.posCharge.setVisible(True)
+        self.negCharge.setVisible(True)
+
+    @overrides
+    def leaveEvent(self, event: QEvent) -> None:
+        self.posCharge.setHidden(True)
+        self.negCharge.setHidden(True)
+
+    def refresh(self):
+        if self.charge() == 0:
+            self.btnProgress.setIcon(self._idleIcon)
+        else:
+            self.btnProgress.setIcon(IconRegistry.charge_icon(self.charge()))
+
+        self._updateButtons()
+
+    @abstractmethod
+    def charge(self) -> int:
+        pass
+
+    @abstractmethod
+    def _changeCharge(self, charge: int):
+        pass
+
+    def _updateButtons(self):
+        self.posCharge.setEnabled(True)
+        self.negCharge.setEnabled(True)
+
+        if self.charge() == 3:
+            self.posCharge.setDisabled(True)
+        elif self.charge() == -3:
+            self.negCharge.setDisabled(True)
+
+
+class ScenePlotGeneralProgressEditor(ProgressEditor):
+    charged = pyqtSignal()
+
+    def __init__(self, plotReference: ScenePlotReference, parent=None):
+        super().__init__(parent)
+        self.plotReference = plotReference
+
+        # self.plot_value_charge: Optional[ScenePlotValueCharge] = None
+        # for v in self.plotReference.data.values:
+        #     if v.plot_value_id == plotReference.plot.default_value.id:
+        #         self.plot_value_charge = v
+        #
+        # if self.plot_value_charge is None:
+        #     self.plot_value_charge = ScenePlotValueCharge(self.plotReference.plot.id, 0)
+        #     self.plotReference.data.values.append(self.plot_value_charge)
+
+        self.refresh()
+
+    @abstractmethod
+    def charge(self) -> int:
+        return self.plotReference.data.charge
+
+    @overrides
+    def _changeCharge(self, charge: int):
+        self.plotReference.data.charge += charge
+        self.refresh()
+        self.charged.emit()
 
 
 class ScenePlotValueChargeWidget(QWidget):
@@ -148,6 +243,7 @@ class ScenePlotValueChargeWidget(QWidget):
 
 class ScenePlotValueEditor(QWidget):
     charged = pyqtSignal(PlotValue, ScenePlotValueCharge)
+    generalProgressCharged = pyqtSignal()
 
     def __init__(self, plotReference: ScenePlotReference, parent=None):
         super().__init__(parent)
@@ -160,17 +256,16 @@ class ScenePlotValueEditor(QWidget):
         self._text.setProperty('rounded', True)
         self._text.setProperty('white-bg', True)
         self._text.setPlaceholderText('Describe how the scene is related to this storyline')
-        self._text.setMaximumSize(200, 180)
+        self._text.setMaximumSize(180, 150)
         self._text.setText(self.plotReference.data.comment)
         self._text.textChanged.connect(self._textChanged)
         self.layout().addWidget(self._text)
         self.layout().addWidget(line(color='lightgrey'))
 
         if self.plotReference.plot.default_value_enabled:
-            wdg = ScenePlotValueChargeWidget(self.plotReference, self.plotReference.plot.default_value)
-            wdg.charged.connect(self.charged.emit)
-            # self.layout().addWidget(QLabel('General progress or setback'))
-            self.layout().addWidget(wdg)
+            wdg = ScenePlotGeneralProgressEditor(self.plotReference)
+            wdg.charged.connect(self.generalProgressCharged)
+            self.layout().addWidget(wrap(wdg, margin_left=15), alignment=Qt.AlignmentFlag.AlignCenter)
             self.layout().addWidget(line(color='lightgrey'))
 
         # if self.plotReference.plot.values:
@@ -238,6 +333,7 @@ class ScenePlotSelectorMenu(MenuWidget):
 
 class ScenePlotLabels(QWidget):
     reset = pyqtSignal()
+    generalProgressCharged = pyqtSignal()
 
     def __init__(self, plotref: ScenePlotReference, parent=None):
         super().__init__(parent)
@@ -259,6 +355,7 @@ class ScenePlotLabels(QWidget):
 
         self._plotValueDisplay = PlotValuesDisplay(self._plotref)
         self._plotValueEditor.charged.connect(self._plotValueDisplay.updateValue)
+        self._plotValueEditor.generalProgressCharged.connect(self.generalProgressCharged)
 
         for value in self._plotref.data.values:
             plot_value = value.plot_value(self._plotref.plot)

--- a/src/main/python/plotlyst/view/widget/scene/plot.py
+++ b/src/main/python/plotlyst/view/widget/scene/plot.py
@@ -137,14 +137,20 @@ class ProgressEditor(QWidget):
     def refresh(self):
         if self.charge() == 0:
             self.btnProgress.setIcon(self._idleIcon)
-        else:
-            self.btnProgress.setIcon(IconRegistry.charge_icon(self.charge()))
-
         if self.altCharge() == 0:
             self.btnProgressAlt.setHidden(True)
+
+        if self.charge() == abs(self.altCharge()):
+            if self.charge():
+                self.btnProgress.setIcon(IconRegistry.trade_off_charge_icon(self.charge()))
+            else:
+                self.btnProgress.setIcon(self._idleIcon)
+            self.btnProgressAlt.setHidden(True)
         else:
-            self.btnProgressAlt.setVisible(True)
-            self.btnProgressAlt.setIcon(IconRegistry.charge_icon(self.altCharge()))
+            self.btnProgress.setIcon(IconRegistry.charge_icon(self.charge()))
+            if self.altCharge():
+                self.btnProgressAlt.setVisible(True)
+                self.btnProgressAlt.setIcon(IconRegistry.charge_icon(self.altCharge()))
 
         self._updateButtons()
 

--- a/test.sh
+++ b/test.sh
@@ -7,4 +7,4 @@ set -e
 ./gen.sh
 export PLOTLYST_TEST_ENV=1
 export PYTHONPATH=src/main/python
-python -X faulthandler -m pytest src/main/python/plotlyst  --cov=src.main.python.plotlyst --junitxml=report.xml --cov-report html:coverage --cov-report term -v --color=yes
+python -X faulthandler -m pytest src/main/python/plotlyst  --cov=plotlyst --junitxml=report.xml --cov-report html:coverage --cov-report term -v --color=yes


### PR DESCRIPTION
- [x] editor widget
  - [x] big icon
  - [x] plus, minus charges on the side on hover
- [x] domain
- [x] change charge per scene
- [x] restore charge
- [x] persist
- [x] same widget for storyline popup
- [x] calculate general progress based on storylines
- [x] bittersweet