### PR TITLE
Improve performance of scene refresh

### DIFF
--- a/src/main/python/plotlyst/common.py
+++ b/src/main/python/plotlyst/common.py
@@ -134,10 +134,12 @@ class Timer:
     def start(self):
         self._start = timer()
 
-    def end(self) -> float:
+    def end(self, suffix: str = '') -> float:
         end = timer()
         self._elapsed = end - self._start
-        print(f'{self._prefix}: {self._elapsed}')
+        if suffix:
+            suffix = f'[{suffix}]'
+        print(f'{self._prefix}: {self._elapsed} {suffix}')
 
         return self._elapsed
 

--- a/src/main/python/plotlyst/events.py
+++ b/src/main/python/plotlyst/events.py
@@ -42,6 +42,11 @@ class CharacterDeletedEvent(Event):
 
 
 @dataclass
+class SceneAddedEvent(Event):
+    scene: Scene
+
+
+@dataclass
 class SceneChangedEvent(Event):
     scene: Scene
 

--- a/src/main/python/plotlyst/model/scenes_model.py
+++ b/src/main/python/plotlyst/model/scenes_model.py
@@ -50,6 +50,7 @@ class BaseScenesTableModel:
 class ScenesTableModel(AbstractHorizontalHeaderBasedTableModel, BaseScenesTableModel):
     orderChanged = pyqtSignal()
     valueChanged = pyqtSignal(QModelIndex)
+    sceneChanged = pyqtSignal(Scene)
     SceneRole = Qt.ItemDataRole.UserRole + 1
 
     MimeType: str = 'application/scene'
@@ -183,6 +184,7 @@ class ScenesTableModel(AbstractHorizontalHeaderBasedTableModel, BaseScenesTableM
         else:
             return False
         self.valueChanged.emit(index)
+        self.sceneChanged.emit(scene)
         return True
 
     @overrides

--- a/src/main/python/plotlyst/test/view/test_scene_editor.py
+++ b/src/main/python/plotlyst/test/view/test_scene_editor.py
@@ -19,6 +19,7 @@ def test_editor_with_new_scene(qtbot):
     view: SceneEditor = editor(qtbot, novel)
     scene = novel.new_scene()
     novel.scenes.append(scene)
+    view.refresh()
     view.set_scene(scene)
 
     assert view.ui.wdgPov.btnAvatar.text() == 'POV'

--- a/src/main/python/plotlyst/test/view/test_scenes.py
+++ b/src/main/python/plotlyst/test/view/test_scenes.py
@@ -5,26 +5,10 @@ from PyQt6.QtWidgets import QSpinBox
 from plotlyst.core.client import client
 from plotlyst.model.scenes_model import ScenesTableModel, ScenesStageTableModel
 from plotlyst.test.common import create_character, start_new_scene_editor, assert_data, go_to_scenes, \
-    click_on_item, patch_confirmed
+    click_on_item
 from plotlyst.view.comments_view import CommentWidget
 from plotlyst.view.main_window import MainWindow
 from plotlyst.view.scenes_view import ScenesOutlineView
-
-
-def test_create_new_scene(qtbot, filled_window: MainWindow):
-    scenes: ScenesOutlineView = start_new_scene_editor(filled_window)
-
-    qtbot.keyClicks(scenes.editor.ui.lineTitle, 'New scene')
-    scenes.editor.ui.sbDay.setValue(1)
-
-    scenes.editor.ui.btnClose.click()
-
-    row = scenes.ui.tblScenes.model().rowCount() - 1
-    assert_data(scenes.ui.tblScenes.model(), 'New scene', row, 1)
-    assert filled_window.novel.scenes
-    assert filled_window.novel.scenes[row].title == 'New scene'
-    assert filled_window.novel.scenes[row].purpose is None
-    assert filled_window.novel.scenes[row].day == 1
 
 
 def test_scene_characters(qtbot, filled_window: MainWindow):
@@ -45,26 +29,6 @@ def test_scene_characters(qtbot, filled_window: MainWindow):
     actions[6].trigger()
     view.editor.ui.btnClose.click()
     assert view.novel.scenes[3].pov == view.novel.characters[6]
-
-
-def test_scene_deletion(qtbot, filled_window: MainWindow, monkeypatch):
-    view: ScenesOutlineView = go_to_scenes(filled_window)
-    view.ui.btnTableView.click()
-
-    click_on_item(qtbot, view.ui.tblScenes, 0, ScenesTableModel.ColTitle)
-    assert view.ui.btnEdit.isEnabled()
-    assert view.ui.btnDelete.isEnabled()
-
-    patch_confirmed(monkeypatch, False)
-    view.ui.btnDelete.click()
-    assert len(view.novel.scenes) == 2
-    assert_data(view.tblModel, 'Scene 1', 0, ScenesTableModel.ColTitle)
-
-    patch_confirmed(monkeypatch)
-    view.ui.btnDelete.click()
-    assert len(view.novel.scenes) == 1
-    assert_data(view.tblModel, 'Scene 2', 0, ScenesTableModel.ColTitle)
-    assert view.tblModel.rowCount() == 1
 
 
 def test_scene_edition(qtbot, filled_window: MainWindow):

--- a/src/main/python/plotlyst/view/manuscript_view.py
+++ b/src/main/python/plotlyst/view/manuscript_view.py
@@ -59,7 +59,7 @@ from plotlyst.view.widget.utility import ask_for_resource
 class ManuscriptView(AbstractNovelView):
 
     def __init__(self, novel: Novel):
-        super().__init__(novel, [NovelUpdatedEvent, SceneChangedEvent, ChapterChangedEvent, SceneDeletedEvent])
+        super().__init__(novel, [NovelUpdatedEvent])
         self.ui = Ui_ManuscriptView()
         self.ui.setupUi(self.widget)
         self.ui.splitter.setSizes([150, 500])

--- a/src/main/python/plotlyst/view/scene_editor.py
+++ b/src/main/python/plotlyst/view/scene_editor.py
@@ -195,7 +195,8 @@ class SceneEditor(QObject, EventListener):
         self.ui.wdgPov.setVisible(self.novel.prefs.toggled(NovelSetting.Track_pov))
 
         dispatcher = event_dispatchers.instance(self.novel)
-        dispatcher.register(self, NovelAboutToSyncEvent, NovelStorylinesToggleEvent, NovelStructureToggleEvent, NovelPovTrackingToggleEvent)
+        dispatcher.register(self, NovelAboutToSyncEvent, NovelStorylinesToggleEvent, NovelStructureToggleEvent,
+                            NovelPovTrackingToggleEvent)
 
     @overrides
     def event_received(self, event: Event):
@@ -210,9 +211,11 @@ class SceneEditor(QObject, EventListener):
         elif isinstance(event, NovelPovTrackingToggleEvent):
             self.ui.wdgPov.setVisible(event.toggled)
 
+    def refresh(self):
+        self.ui.treeScenes.refresh()
+
     def set_scene(self, scene: Scene):
         self.scene = scene
-        self.ui.treeScenes.refresh()
         self.ui.treeScenes.selectScene(self.scene)
 
         self._update_pov_avatar()

--- a/src/main/python/plotlyst/view/scene_editor.py
+++ b/src/main/python/plotlyst/view/scene_editor.py
@@ -39,7 +39,7 @@ from plotlyst.env import app_env
 from plotlyst.event.core import EventListener, Event, emit_event
 from plotlyst.event.handler import event_dispatchers
 from plotlyst.events import NovelAboutToSyncEvent, SceneStoryBeatChangedEvent, \
-    NovelStorylinesToggleEvent, NovelStructureToggleEvent, NovelPovTrackingToggleEvent
+    NovelStorylinesToggleEvent, NovelStructureToggleEvent, NovelPovTrackingToggleEvent, SceneChangedEvent
 from plotlyst.model.characters_model import CharactersSceneAssociationTableModel
 from plotlyst.service.cache import acts_registry
 from plotlyst.service.persistence import RepositoryPersistenceManager
@@ -405,6 +405,7 @@ class SceneEditor(QObject, EventListener):
         #     self.repo.insert_scene(self.novel, self.scene)
         # else:
         self.repo.update_scene(self.scene)
+        emit_event(self.novel, SceneChangedEvent(self, self.scene))
 
         if not self.scene.document:
             self.scene.document = Document('', scene_id=self.scene.id)

--- a/src/main/python/plotlyst/view/scenes_view.py
+++ b/src/main/python/plotlyst/view/scenes_view.py
@@ -41,7 +41,7 @@ from plotlyst.events import SceneChangedEvent, SceneDeletedEvent, NovelStoryStru
     SceneSelectedEvent, SceneSelectionClearedEvent, ActiveSceneStageChanged, \
     ChapterChangedEvent, AvailableSceneStagesChanged, CharacterChangedEvent, CharacterDeletedEvent, \
     NovelAboutToSyncEvent, NovelSyncEvent, NovelStoryStructureActivationRequest, NovelPanelCustomizationEvent, \
-    NovelStorylinesToggleEvent, NovelStructureToggleEvent, NovelPovTrackingToggleEvent
+    NovelStorylinesToggleEvent, NovelStructureToggleEvent, NovelPovTrackingToggleEvent, SceneAddedEvent
 from plotlyst.events import SceneOrderChangedEvent
 from plotlyst.model.common import SelectionItemsModel
 from plotlyst.model.novel import NovelStagesModel
@@ -112,7 +112,7 @@ class ScenesOutlineView(AbstractNovelView):
 
     def __init__(self, novel: Novel):
         super().__init__(novel,
-                         [NovelStoryStructureUpdated, CharacterChangedEvent, SceneChangedEvent, ChapterChangedEvent,
+                         [NovelStoryStructureUpdated, CharacterChangedEvent, SceneAddedEvent, SceneChangedEvent, ChapterChangedEvent,
                           SceneDeletedEvent,
                           SceneOrderChangedEvent, NovelAboutToSyncEvent, NovelStorylinesToggleEvent,
                           NovelStructureToggleEvent, NovelPovTrackingToggleEvent])
@@ -312,6 +312,7 @@ class ScenesOutlineView(AbstractNovelView):
 
         super(ScenesOutlineView, self).event_received(event)
 
+    @busy
     @overrides
     def refresh(self):
         self.tblModel.modelReset.emit()

--- a/src/main/python/plotlyst/view/widget/scene/tree.py
+++ b/src/main/python/plotlyst/view/widget/scene/tree.py
@@ -35,7 +35,7 @@ from plotlyst.core.domain import Scene, Novel, Chapter, ChapterType
 from plotlyst.event.core import Event, EventListener, emit_event
 from plotlyst.event.handler import event_dispatchers
 from plotlyst.events import SceneDeletedEvent, \
-    SceneChangedEvent
+    SceneChangedEvent, SceneAddedEvent
 from plotlyst.events import SceneOrderChangedEvent, ChapterChangedEvent
 from plotlyst.service.persistence import RepositoryPersistenceManager, delete_scene
 from plotlyst.view.common import action, insert_before_the_end
@@ -194,7 +194,7 @@ class ScenesTreeView(TreeView, EventListener):
     def setNovel(self, novel: Novel, readOnly: bool = False):
         self._novel = novel
         dispatcher = event_dispatchers.instance(self._novel)
-        dispatcher.register(self, SceneOrderChangedEvent, SceneDeletedEvent, SceneChangedEvent)
+        dispatcher.register(self, SceneOrderChangedEvent, SceneDeletedEvent, SceneAddedEvent, SceneChangedEvent)
         self._readOnly = readOnly
 
         self.refresh()
@@ -284,7 +284,7 @@ class ScenesTreeView(TreeView, EventListener):
         insert_before_the_end(self._centralWidget, wdg)
 
         self.repo.insert_scene(self._novel, scene)
-        emit_event(self._novel, SceneChangedEvent(self, scene), delay=10)
+        emit_event(self._novel, SceneAddedEvent(self, scene), delay=10)
         self.sceneAdded.emit(scene)
 
     def addPrologue(self):


### PR DESCRIPTION
- [x] new scene added:
  - [x] in view
    - [x] _new_scene
    - [x] _insert_scene_after [table and card]
  - [x] in tree
    - [x] SceneAddedEvent
    - [x] sceneAdded signal
- [x] scene deleted
  - [x] btn in view
  - [x] SceneDeletedEvent
- [x] scene changed
  - [x] SceneChangedEvent
  - [x] editor
  - [x] inline table
- [x] create card after new scene
- [x] insert card
- [x] full card refresh
- [x] quick card refresh
- [x] reorder cards
- [x] emit sceneadded signal too in tree
- [x] emit changed signal from editor