### PR TITLE
Undo-redo for graphics editor

### DIFF
--- a/src/main/python/plotlyst/view/widget/character/network.py
+++ b/src/main/python/plotlyst/view/widget/character/network.py
@@ -20,7 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from typing import Optional
 
 from PyQt6.QtCore import pyqtSignal
-from PyQt6.QtGui import QAction
+from PyQt6.QtGui import QAction, QUndoStack
 from overrides import overrides
 from qthandy import vline
 from qtmenu import GridMenuWidget
@@ -68,7 +68,7 @@ class CharacterNetworkView(NetworkGraphicsView):
         # self._btnAddSticker.setDisabled(True)
         # self._btnAddSticker.setToolTip('Feature is not yet available')
 
-        self._connectorEditor = RelationConnectorToolbar(self)
+        self._connectorEditor = RelationConnectorToolbar(self.undoStack, self)
         self._connectorEditor.setVisible(False)
 
     @overrides
@@ -138,8 +138,8 @@ class RelationSelector(GridMenuWidget):
 
 
 class RelationConnectorToolbar(ConnectorToolbar):
-    def __init__(self, parent=None):
-        super().__init__(parent)
+    def __init__(self, undoStack: QUndoStack, parent=None):
+        super().__init__(undoStack, parent)
         self._btnRelationType = RelationsButton()
 
         self._relationSelector: Optional[RelationSelector] = None

--- a/src/main/python/plotlyst/view/widget/graphics/commands.py
+++ b/src/main/python/plotlyst/view/widget/graphics/commands.py
@@ -27,6 +27,7 @@ from overrides import overrides
 
 class MergeableCommandType(Enum):
     PEN_WIDTH = auto()
+    TEXT = auto()
 
 
 class MergeableGraphicsItemCommand(QUndoCommand):

--- a/src/main/python/plotlyst/view/widget/graphics/commands.py
+++ b/src/main/python/plotlyst/view/widget/graphics/commands.py
@@ -133,8 +133,12 @@ class PosChangedCommand(QUndoCommand):
             return
         self.item.setPosCommandEnabled(False)
         self.item.setPos(self.new)
+        self.item.updatePos()
+        self.item.setPosCommandEnabled(True)
 
     @overrides
     def undo(self) -> None:
         self.item.setPosCommandEnabled(False)
         self.item.setPos(self.old)
+        self.item.updatePos()
+        self.item.setPosCommandEnabled(True)

--- a/src/main/python/plotlyst/view/widget/graphics/commands.py
+++ b/src/main/python/plotlyst/view/widget/graphics/commands.py
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from enum import Enum, auto
 from typing import Any
 
+from PyQt6.QtCore import QPointF
 from PyQt6.QtGui import QUndoCommand
 from PyQt6.QtWidgets import QGraphicsItem
 from overrides import overrides
@@ -115,3 +116,25 @@ class NoteEditorCommand(QUndoCommand):
     @overrides
     def undo(self) -> None:
         self.item.setText(self.oldText, self.oldHeight)
+
+
+class PosChangedCommand(QUndoCommand):
+    def __init__(self, item: QGraphicsItem, old: QPointF, new: QPointF, parent=None):
+        super().__init__(parent)
+        self.item = item
+        self.old = old
+        self.new = new
+        self._first = True
+
+    @overrides
+    def redo(self) -> None:
+        if self._first:
+            self._first = False
+            return
+        self.item.setPosCommandEnabled(False)
+        self.item.setPos(self.new)
+
+    @overrides
+    def undo(self) -> None:
+        self.item.setPosCommandEnabled(False)
+        self.item.setPos(self.old)

--- a/src/main/python/plotlyst/view/widget/graphics/commands.py
+++ b/src/main/python/plotlyst/view/widget/graphics/commands.py
@@ -26,7 +26,6 @@ from overrides import overrides
 
 
 class MergeableCommandType(Enum):
-    PEN_WIDTH = auto()
     TEXT = auto()
     SIZE = auto()
 
@@ -58,6 +57,16 @@ class MergeableGraphicsItemCommand(QUndoCommand):
     @overrides
     def undo(self) -> None:
         self.func(self.old)
+
+
+class TextEditingCommand(MergeableGraphicsItemCommand):
+    def __init__(self, item: QGraphicsItem, new: Any, parent=None):
+        super().__init__(MergeableCommandType.TEXT, item, item.setText, item.text(), new, parent)
+
+
+class SizeEditingCommand(MergeableGraphicsItemCommand):
+    def __init__(self, item: QGraphicsItem, new: Any, parent=None):
+        super().__init__(MergeableCommandType.SIZE, item, item.setSize, item.size(), new, parent)
 
 
 class GraphicsItemCommand(QUndoCommand):

--- a/src/main/python/plotlyst/view/widget/graphics/commands.py
+++ b/src/main/python/plotlyst/view/widget/graphics/commands.py
@@ -18,7 +18,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 from enum import Enum, auto
-from typing import Any
+from typing import Any, Optional, List
 
 from PyQt6.QtCore import QPointF
 from PyQt6.QtGui import QUndoCommand
@@ -164,10 +164,12 @@ class ItemAdditionCommand(QUndoCommand):
 
 
 class ItemRemovalCommand(QUndoCommand):
-    def __init__(self, scene: QGraphicsScene, item: QGraphicsItem, parent=None):
+    def __init__(self, scene: QGraphicsScene, item: QGraphicsItem, connectors: Optional[List[QGraphicsItem]] = None,
+                 parent=None):
         super().__init__(parent)
         self.scene = scene
         self.item = item
+        self.connectors = connectors
         self._first = True
 
     @overrides
@@ -179,7 +181,7 @@ class ItemRemovalCommand(QUndoCommand):
 
     @overrides
     def undo(self) -> None:
-        self.scene.addNetworkItem(self.item)
+        self.scene.addNetworkItem(self.item, self.connectors)
 
 # class ConnectorAdditionCommand(QUndoCommand):
 #     def __init__(self, scene: QGraphicsScene, item: QGraphicsItem, parent=None):

--- a/src/main/python/plotlyst/view/widget/graphics/commands.py
+++ b/src/main/python/plotlyst/view/widget/graphics/commands.py
@@ -1,0 +1,63 @@
+"""
+Plotlyst
+Copyright (C) 2021-2024  Zsolt Kovari
+
+This file is part of Plotlyst.
+
+Plotlyst is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Plotlyst is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+from enum import Enum, auto
+from typing import Any
+
+from PyQt6.QtGui import QUndoCommand
+from PyQt6.QtWidgets import QGraphicsItem
+from overrides import overrides
+
+
+class CommandType(Enum):
+    PEN_WIDTH = auto()
+
+
+class BaseGraphicsItemCommand(QUndoCommand):
+    def __init__(self, type: CommandType, item: QGraphicsItem, parent=None):
+        super().__init__(parent)
+        self.type = type
+        self.item = item
+
+    @overrides
+    def id(self) -> int:
+        return self.type.value
+
+
+class GraphicsItemCommand(BaseGraphicsItemCommand):
+    def __init__(self, type: CommandType, item: QGraphicsItem, func, old: Any, new: Any, parent=None):
+        super().__init__(type, item, parent)
+        self.func = func
+        self.old = old
+        self.new = new
+
+    @overrides
+    def mergeWith(self, other: 'GraphicsItemCommand') -> bool:
+        if self.type == other.type and self.item is other.item:
+            self.new = other.new
+            return True
+        return False
+
+    @overrides
+    def redo(self) -> None:
+        self.func(self.new)
+
+    @overrides
+    def undo(self) -> None:
+        self.func(self.old)

--- a/src/main/python/plotlyst/view/widget/graphics/commands.py
+++ b/src/main/python/plotlyst/view/widget/graphics/commands.py
@@ -24,6 +24,8 @@ from PyQt6.QtGui import QUndoCommand
 from PyQt6.QtWidgets import QGraphicsItem
 from overrides import overrides
 
+from plotlyst.view.widget.graphics.items import NoteItem
+
 
 class MergeableCommandType(Enum):
     TEXT = auto()
@@ -84,3 +86,34 @@ class GraphicsItemCommand(QUndoCommand):
     @overrides
     def undo(self) -> None:
         self.func(self.old)
+
+
+class NoteEditorCommand(QUndoCommand):
+    def __init__(self, item: NoteItem, oldText: str, oldHeight: int, newText: str, newHeight: int, parent=None):
+        super().__init__(parent)
+        self.type = MergeableCommandType.TEXT
+        self.item = item
+        self.oldText = oldText
+        self.oldHeight = oldHeight
+        self.newText = newText
+        self.newHeight = newHeight
+
+    @overrides
+    def id(self) -> int:
+        return self.type.value
+
+    @overrides
+    def mergeWith(self, other: QUndoCommand) -> bool:
+        if isinstance(other, NoteEditorCommand) and self.item is other.item:
+            self.newText = other.newText
+            self.newHeight = other.newHeight
+            return True
+        return False
+
+    @overrides
+    def redo(self) -> None:
+        self.item.setText(self.newText, self.newHeight)
+
+    @overrides
+    def undo(self) -> None:
+        self.item.setText(self.oldText, self.oldHeight)

--- a/src/main/python/plotlyst/view/widget/graphics/commands.py
+++ b/src/main/python/plotlyst/view/widget/graphics/commands.py
@@ -144,6 +144,31 @@ class PosChangedCommand(QUndoCommand):
         self.item.setPosCommandEnabled(True)
 
 
+class ResizeItemCommand(QUndoCommand):
+    def __init__(self, item: QGraphicsItem, old: QPointF, new: QPointF, parent=None):
+        super().__init__(parent)
+        self.item = item
+        self.old = old
+        self.new = new
+        self._first = True
+
+    @overrides
+    def redo(self) -> None:
+        if self._first:
+            self._first = False
+            return
+        self.item.setPosCommandEnabled(False)
+        self.item.updatePos()
+        self.item.parentItem().rearrangeSize(self.new)
+        self.item.setPosCommandEnabled(True)
+
+    @overrides
+    def undo(self) -> None:
+        self.item.setPosCommandEnabled(False)
+        self.item.updatePos()
+        self.item.parentItem().rearrangeSize(self.old)
+        self.item.setPosCommandEnabled(True)
+
 class ItemAdditionCommand(QUndoCommand):
     def __init__(self, scene: QGraphicsScene, item: QGraphicsItem, parent=None):
         super().__init__(parent)

--- a/src/main/python/plotlyst/view/widget/graphics/commands.py
+++ b/src/main/python/plotlyst/view/widget/graphics/commands.py
@@ -28,6 +28,7 @@ from overrides import overrides
 class MergeableCommandType(Enum):
     PEN_WIDTH = auto()
     TEXT = auto()
+    SIZE = auto()
 
 
 class MergeableGraphicsItemCommand(QUndoCommand):

--- a/src/main/python/plotlyst/view/widget/graphics/commands.py
+++ b/src/main/python/plotlyst/view/widget/graphics/commands.py
@@ -145,26 +145,6 @@ class PosChangedCommand(QUndoCommand):
 
 
 class ItemAdditionCommand(QUndoCommand):
-    def __init__(self, scene: QGraphicsScene, item: QGraphicsItem, pos: QPointF, parent=None):
-        super().__init__(parent)
-        self.scene = scene
-        self.item = item
-        self.pos = pos
-        self._first = True
-
-    @overrides
-    def redo(self) -> None:
-        if self._first:
-            self._first = False
-            return
-        self.scene.addNodeItem(self.item)
-
-    @overrides
-    def undo(self) -> None:
-        self.scene.removeNodeItem(self.item)
-
-
-class ConnectorAdditionCommand(QUndoCommand):
     def __init__(self, scene: QGraphicsScene, item: QGraphicsItem, parent=None):
         super().__init__(parent)
         self.scene = scene
@@ -176,8 +156,26 @@ class ConnectorAdditionCommand(QUndoCommand):
         if self._first:
             self._first = False
             return
-        self.scene.addConnectorItem(self.item)
+        self.scene.addNetworkItem(self.item)
 
     @overrides
     def undo(self) -> None:
-        self.scene.removeConnectorItem(self.item)
+        self.scene.removeNetworkItem(self.item)
+
+# class ConnectorAdditionCommand(QUndoCommand):
+#     def __init__(self, scene: QGraphicsScene, item: QGraphicsItem, parent=None):
+#         super().__init__(parent)
+#         self.scene = scene
+#         self.item = item
+#         self._first = True
+#
+#     @overrides
+#     def redo(self) -> None:
+#         if self._first:
+#             self._first = False
+#             return
+#         self.scene.addConnectorItem(self.item)
+#
+#     @overrides
+#     def undo(self) -> None:
+#         self.scene.removeConnectorItem(self.item)

--- a/src/main/python/plotlyst/view/widget/graphics/commands.py
+++ b/src/main/python/plotlyst/view/widget/graphics/commands.py
@@ -24,8 +24,6 @@ from PyQt6.QtGui import QUndoCommand
 from PyQt6.QtWidgets import QGraphicsItem
 from overrides import overrides
 
-from plotlyst.view.widget.graphics.items import NoteItem
-
 
 class MergeableCommandType(Enum):
     TEXT = auto()
@@ -89,7 +87,7 @@ class GraphicsItemCommand(QUndoCommand):
 
 
 class NoteEditorCommand(QUndoCommand):
-    def __init__(self, item: NoteItem, oldText: str, oldHeight: int, newText: str, newHeight: int, parent=None):
+    def __init__(self, item: QGraphicsItem, oldText: str, oldHeight: int, newText: str, newHeight: int, parent=None):
         super().__init__(parent)
         self.type = MergeableCommandType.TEXT
         self.item = item

--- a/src/main/python/plotlyst/view/widget/graphics/commands.py
+++ b/src/main/python/plotlyst/view/widget/graphics/commands.py
@@ -162,3 +162,22 @@ class ItemAdditionCommand(QUndoCommand):
     @overrides
     def undo(self) -> None:
         self.scene.removeNodeItem(self.item)
+
+
+class ConnectorAdditionCommand(QUndoCommand):
+    def __init__(self, scene: QGraphicsScene, item: QGraphicsItem, parent=None):
+        super().__init__(parent)
+        self.scene = scene
+        self.item = item
+        self._first = True
+
+    @overrides
+    def redo(self) -> None:
+        if self._first:
+            self._first = False
+            return
+        self.scene.addConnectorItem(self.item)
+
+    @overrides
+    def undo(self) -> None:
+        self.scene.removeConnectorItem(self.item)

--- a/src/main/python/plotlyst/view/widget/graphics/commands.py
+++ b/src/main/python/plotlyst/view/widget/graphics/commands.py
@@ -22,7 +22,7 @@ from typing import Any
 
 from PyQt6.QtCore import QPointF
 from PyQt6.QtGui import QUndoCommand
-from PyQt6.QtWidgets import QGraphicsItem
+from PyQt6.QtWidgets import QGraphicsItem, QGraphicsScene
 from overrides import overrides
 
 
@@ -142,3 +142,23 @@ class PosChangedCommand(QUndoCommand):
         self.item.setPos(self.old)
         self.item.updatePos()
         self.item.setPosCommandEnabled(True)
+
+
+class ItemAdditionCommand(QUndoCommand):
+    def __init__(self, scene: QGraphicsScene, item: QGraphicsItem, pos: QPointF, parent=None):
+        super().__init__(parent)
+        self.scene = scene
+        self.item = item
+        self.pos = pos
+        self._first = True
+
+    @overrides
+    def redo(self) -> None:
+        if self._first:
+            self._first = False
+            return
+        self.scene.addNodeItem(self.item)
+
+    @overrides
+    def undo(self) -> None:
+        self.scene.removeNodeItem(self.item)

--- a/src/main/python/plotlyst/view/widget/graphics/commands.py
+++ b/src/main/python/plotlyst/view/widget/graphics/commands.py
@@ -162,6 +162,25 @@ class ItemAdditionCommand(QUndoCommand):
     def undo(self) -> None:
         self.scene.removeNetworkItem(self.item)
 
+
+class ItemRemovalCommand(QUndoCommand):
+    def __init__(self, scene: QGraphicsScene, item: QGraphicsItem, parent=None):
+        super().__init__(parent)
+        self.scene = scene
+        self.item = item
+        self._first = True
+
+    @overrides
+    def redo(self) -> None:
+        if self._first:
+            self._first = False
+            return
+        self.scene.removeNetworkItem(self.item)
+
+    @overrides
+    def undo(self) -> None:
+        self.scene.addNetworkItem(self.item)
+
 # class ConnectorAdditionCommand(QUndoCommand):
 #     def __init__(self, scene: QGraphicsScene, item: QGraphicsItem, parent=None):
 #         super().__init__(parent)

--- a/src/main/python/plotlyst/view/widget/graphics/editor.py
+++ b/src/main/python/plotlyst/view/widget/graphics/editor.py
@@ -39,7 +39,8 @@ from plotlyst.core.domain import GraphicsItemType, NODE_SUBTYPE_DISTURBANCE, NOD
 from plotlyst.view.common import shadow, tool_btn, ExclusiveOptionalButtonGroup
 from plotlyst.view.icons import IconRegistry
 from plotlyst.view.layout import group
-from plotlyst.view.widget.graphics.commands import GraphicsItemCommand, CommandType
+from plotlyst.view.widget.graphics.commands import GraphicsItemCommand, MergeableCommandType, \
+    MergeableGraphicsItemCommand
 from plotlyst.view.widget.graphics.items import EventItem, ConnectorItem, NoteItem, CharacterItem, IconItem
 from plotlyst.view.widget.input import FontSizeSpinBox, AutoAdjustableLineEdit, AutoAdjustableTextEdit
 from plotlyst.view.widget.utility import ColorPicker, IconSelectorDialog
@@ -442,21 +443,27 @@ class ConnectorToolbar(PaintedItemBasedToolbar):
     def _penStyleChanged(self):
         btn = self._lineBtnGroup.checkedButton()
         if btn and self._item:
-            self._item.setPenStyle(btn.penStyle())
+            command = GraphicsItemCommand(self._item, self._item.setPenStyle,
+                                          self._item.penStyle(), btn.penStyle())
+            self.undoStack.push(command)
 
     def _widthChanged(self, value: int):
         if self._item:
-            command = GraphicsItemCommand(CommandType.PEN_WIDTH, self._item, self._item.setPenWidth,
-                                          self._item.penWidth(), value)
+            command = MergeableGraphicsItemCommand(MergeableCommandType.PEN_WIDTH, self._item, self._item.setPenWidth,
+                                                   self._item.penWidth(), value)
             self.undoStack.push(command)
 
     def _arrowStartClicked(self, toggled: bool):
         if self._item:
-            self._item.setStartArrowEnabled(toggled)
+            command = GraphicsItemCommand(self._item, self._item.setStartArrowEnabled,
+                                          self._item.startArrowEnabled(), toggled)
+            self.undoStack.push(command)
 
     def _arrowEndClicked(self, toggled: bool):
         if self._item:
-            self._item.setEndArrowEnabled(toggled)
+            command = GraphicsItemCommand(self._item, self._item.setEndArrowEnabled,
+                                          self._item.endArrowEnabled(), toggled)
+            self.undoStack.push(command)
 
 
 class NoteToolbar(PaintedItemBasedToolbar):

--- a/src/main/python/plotlyst/view/widget/graphics/editor.py
+++ b/src/main/python/plotlyst/view/widget/graphics/editor.py
@@ -355,7 +355,6 @@ class PaintedItemBasedToolbar(BaseItemToolbar):
             command = GraphicsItemCommand(self._item, self._item.setIcon,
                                           self._item.icon(), result[0])
             self.undoStack.push(command)
-            # self._item.setIcon(result[0])
             self._updateIcon(result[0])
 
     def _colorChanged(self, color: QColor):
@@ -363,7 +362,6 @@ class PaintedItemBasedToolbar(BaseItemToolbar):
             command = GraphicsItemCommand(self._item, self._item.setColor,
                                           self._item.color(), color)
             self.undoStack.push(command)
-            # self._item.setColor(color)
             self._updateColor(color.name())
             pass
 
@@ -501,7 +499,9 @@ class NoteToolbar(PaintedItemBasedToolbar):
 
     def _transparentClicked(self, toggled: bool):
         if self._item:
-            self._item.setTransparent(toggled)
+            command = GraphicsItemCommand(self._item, self._item.setTransparent,
+                                          self._item.transparent(), toggled)
+            self.undoStack.push(command)
 
 
 class IconItemToolbar(PaintedItemBasedToolbar):

--- a/src/main/python/plotlyst/view/widget/graphics/editor.py
+++ b/src/main/python/plotlyst/view/widget/graphics/editor.py
@@ -353,12 +353,18 @@ class PaintedItemBasedToolbar(BaseItemToolbar):
     def _showIconSelector(self):
         result = IconSelectorDialog.popup(pickColor=False)
         if result and self._item:
-            self._item.setIcon(result[0])
+            command = GraphicsItemCommand(self._item, self._item.setIcon,
+                                          self._item.icon(), result[0])
+            self.undoStack.push(command)
+            # self._item.setIcon(result[0])
             self._updateIcon(result[0])
 
     def _colorChanged(self, color: QColor):
         if self._item:
-            self._item.setColor(color)
+            command = GraphicsItemCommand(self._item, self._item.setColor,
+                                          self._item.color(), color)
+            self.undoStack.push(command)
+            # self._item.setColor(color)
             self._updateColor(color.name())
             pass
 
@@ -438,7 +444,9 @@ class ConnectorToolbar(PaintedItemBasedToolbar):
 
     def _textEdited(self):
         if self._item:
-            self._item.setText(self._textLineEdit.text())
+            command = MergeableGraphicsItemCommand(MergeableCommandType.TEXT, self._item, self._item.setText,
+                                                   self._item.text(), self._textLineEdit.text())
+            self.undoStack.push(command)
 
     def _penStyleChanged(self):
         btn = self._lineBtnGroup.checkedButton()

--- a/src/main/python/plotlyst/view/widget/graphics/editor.py
+++ b/src/main/python/plotlyst/view/widget/graphics/editor.py
@@ -311,7 +311,9 @@ class CharacterToolbar(BaseItemToolbar):
 
     def _sizeChanged(self, value: int):
         if self._item:
-            self._item.setSize(value)
+            command = MergeableGraphicsItemCommand(MergeableCommandType.SIZE, self._item, self._item.setSize,
+                                                   self._item.size(), value)
+            self.undoStack.push(command)
 
     def _characterClicked(self):
         if self._item:
@@ -531,7 +533,9 @@ class IconItemToolbar(PaintedItemBasedToolbar):
 
     def _sizeChanged(self, value: int):
         if self._item:
-            self._item.setSize(value)
+            command = MergeableGraphicsItemCommand(MergeableCommandType.SIZE, self._item, self._item.setSize,
+                                                   self._item.size(), value)
+            self.undoStack.push(command)
 
 
 class EventItemToolbar(PaintedItemBasedToolbar):

--- a/src/main/python/plotlyst/view/widget/graphics/editor.py
+++ b/src/main/python/plotlyst/view/widget/graphics/editor.py
@@ -39,8 +39,7 @@ from plotlyst.core.domain import GraphicsItemType, NODE_SUBTYPE_DISTURBANCE, NOD
 from plotlyst.view.common import shadow, tool_btn, ExclusiveOptionalButtonGroup
 from plotlyst.view.icons import IconRegistry
 from plotlyst.view.layout import group
-from plotlyst.view.widget.graphics.commands import GraphicsItemCommand, MergeableCommandType, \
-    MergeableGraphicsItemCommand
+from plotlyst.view.widget.graphics.commands import GraphicsItemCommand, TextEditingCommand, SizeEditingCommand
 from plotlyst.view.widget.graphics.items import EventItem, ConnectorItem, NoteItem, CharacterItem, IconItem
 from plotlyst.view.widget.input import FontSizeSpinBox, AutoAdjustableLineEdit, AutoAdjustableTextEdit
 from plotlyst.view.widget.utility import ColorPicker, IconSelectorDialog
@@ -311,9 +310,7 @@ class CharacterToolbar(BaseItemToolbar):
 
     def _sizeChanged(self, value: int):
         if self._item:
-            command = MergeableGraphicsItemCommand(MergeableCommandType.SIZE, self._item, self._item.setSize,
-                                                   self._item.size(), value)
-            self.undoStack.push(command)
+            self.undoStack.push(SizeEditingCommand(self._item, value))
 
     def _characterClicked(self):
         if self._item:
@@ -321,7 +318,7 @@ class CharacterToolbar(BaseItemToolbar):
 
     def _textEdited(self):
         if self._item:
-            self._item.setText(self._textLineEdit.text())
+            self.undoStack.push(TextEditingCommand(self._item, self._textLineEdit.text()))
 
 
 class PaintedItemBasedToolbar(BaseItemToolbar):
@@ -432,7 +429,7 @@ class ConnectorToolbar(PaintedItemBasedToolbar):
         super().setItem(connector)
         self._item = None
 
-        self._sbWidth.setValue(connector.penWidth())
+        self._sbWidth.setValue(connector.size())
         self._textLineEdit.setText(connector.text())
         self._arrowStart.setChecked(connector.startArrowEnabled())
         self._arrowEnd.setChecked(connector.endArrowEnabled())
@@ -446,9 +443,7 @@ class ConnectorToolbar(PaintedItemBasedToolbar):
 
     def _textEdited(self):
         if self._item:
-            command = MergeableGraphicsItemCommand(MergeableCommandType.TEXT, self._item, self._item.setText,
-                                                   self._item.text(), self._textLineEdit.text())
-            self.undoStack.push(command)
+            self.undoStack.push(TextEditingCommand(self._item, self._textLineEdit.text()))
 
     def _penStyleChanged(self):
         btn = self._lineBtnGroup.checkedButton()
@@ -459,9 +454,7 @@ class ConnectorToolbar(PaintedItemBasedToolbar):
 
     def _widthChanged(self, value: int):
         if self._item:
-            command = MergeableGraphicsItemCommand(MergeableCommandType.PEN_WIDTH, self._item, self._item.setPenWidth,
-                                                   self._item.penWidth(), value)
-            self.undoStack.push(command)
+            self.undoStack.push(SizeEditingCommand(self._item, value))
 
     def _arrowStartClicked(self, toggled: bool):
         if self._item:
@@ -533,9 +526,7 @@ class IconItemToolbar(PaintedItemBasedToolbar):
 
     def _sizeChanged(self, value: int):
         if self._item:
-            command = MergeableGraphicsItemCommand(MergeableCommandType.SIZE, self._item, self._item.setSize,
-                                                   self._item.size(), value)
-            self.undoStack.push(command)
+            self.undoStack.push(SizeEditingCommand(self._item, value))
 
 
 class EventItemToolbar(PaintedItemBasedToolbar):

--- a/src/main/python/plotlyst/view/widget/graphics/items.py
+++ b/src/main/python/plotlyst/view/widget/graphics/items.py
@@ -1297,6 +1297,9 @@ class NoteItem(NodeItem):
         self.networkScene().nodeChangedEvent(self._node)
         self._refresh()
 
+    def transparent(self) -> bool:
+        return self._node.transparent
+
     def setTransparent(self, transparent: bool):
         self._node.transparent = transparent
         self.networkScene().nodeChangedEvent(self._node)

--- a/src/main/python/plotlyst/view/widget/graphics/items.py
+++ b/src/main/python/plotlyst/view/widget/graphics/items.py
@@ -1289,6 +1289,9 @@ class NoteItem(NodeItem):
     def text(self) -> str:
         return self._node.text
 
+    def height(self) -> int:
+        return self._node.height
+
     def setText(self, text: str, height: int):
         self._node.text = text
         self._textRect.setHeight(height)

--- a/src/main/python/plotlyst/view/widget/graphics/items.py
+++ b/src/main/python/plotlyst/view/widget/graphics/items.py
@@ -913,6 +913,9 @@ class CharacterItem(CircleShapedNodeItem):
         self.update()
         self.networkScene().nodeChangedEvent(self._node)
 
+    def text(self) -> str:
+        return self._node.text
+
     def setText(self, text: str):
         self._node.text = text
         self._refreshLabel()

--- a/src/main/python/plotlyst/view/widget/graphics/items.py
+++ b/src/main/python/plotlyst/view/widget/graphics/items.py
@@ -112,7 +112,10 @@ class ResizeIconItem(QAbstractGraphicsShapeItem):
         if change == QGraphicsItem.GraphicsItemChange.ItemPositionHasChanged and self._activated:
             if self._keepAspectRatio:
                 value.setY(value.x() / self._ratio)
+                # stack: QUndoStack = self.scene().undoStack()
+                # stack.push(GraphicsItemCommand(self, self.setPos, self.pos(), value))
                 self.setPos(value)
+
             self.parentItem().rearrangeSize(value)
         return super().itemChange(change, value)
 

--- a/src/main/python/plotlyst/view/widget/graphics/items.py
+++ b/src/main/python/plotlyst/view/widget/graphics/items.py
@@ -964,7 +964,10 @@ class IconItem(CircleShapedNodeItem):
 
     def setIcon(self, icon: str):
         self._node.icon = icon
-        self._icon = IconRegistry.from_name(self._node.icon, self._node.color)
+        if icon:
+            self._icon = IconRegistry.from_name(self._node.icon, self._node.color)
+        else:
+            self._icon = IconRegistry.from_name('fa5s.icons', 'grey')
         self.update()
         self.networkScene().nodeChangedEvent(self._node)
 
@@ -1094,7 +1097,10 @@ class EventItem(NodeItem):
 
     def setIcon(self, icon: str):
         self._node.icon = icon
-        self._icon = IconRegistry.from_name(self._node.icon, self._node.color)
+        if icon:
+            self._icon = IconRegistry.from_name(self._node.icon, self._node.color)
+        else:
+            self._icon = None
         self._refresh()
         self.networkScene().nodeChangedEvent(self._node)
 

--- a/src/main/python/plotlyst/view/widget/graphics/items.py
+++ b/src/main/python/plotlyst/view/widget/graphics/items.py
@@ -794,6 +794,9 @@ class CircleShapedNodeItem(NodeItem):
         self._socket = FilledSocketItem(0, self)
         self._socket.setVisible(False)
 
+    def size(self) -> int:
+        return self._node.size
+
     def setSize(self, value: int):
         self._node.size = value
         self._size = value

--- a/src/main/python/plotlyst/view/widget/graphics/items.py
+++ b/src/main/python/plotlyst/view/widget/graphics/items.py
@@ -446,7 +446,7 @@ class ConnectorItem(QGraphicsPathItem):
     def setConnector(self, connector: Connector):
         self._connector = None
         self.setPenStyle(connector.pen)
-        self.setPenWidth(connector.width)
+        self.setSize(connector.width)
         self.setStartArrowEnabled(connector.start_arrow_enabled)
         self.setEndArrowEnabled(connector.end_arrow_enabled)
         if connector.color:
@@ -490,10 +490,10 @@ class ConnectorItem(QGraphicsPathItem):
         self.rearrange()
         self.networkScene().connectorChangedEvent(self)
 
-    def penWidth(self) -> int:
+    def size(self) -> int:
         return self.pen().width()
 
-    def setPenWidth(self, width: int):
+    def setSize(self, width: int):
         pen = self.pen()
         pen.setWidth(width)
         self.setPen(pen)

--- a/src/main/python/plotlyst/view/widget/graphics/items.py
+++ b/src/main/python/plotlyst/view/widget/graphics/items.py
@@ -553,10 +553,13 @@ class ConnectorItem(QGraphicsPathItem):
     def icon(self) -> Optional[str]:
         return self._icon
 
-    def setIcon(self, icon: str):
+    def setIcon(self, icon: Optional[str]):
         self._icon = icon
-        self._iconBadge.setIcon(IconRegistry.from_name(self._icon, self._color.name()), self._color)
-        self._iconBadge.setVisible(True)
+        if self._icon:
+            self._iconBadge.setIcon(IconRegistry.from_name(self._icon, self._color.name()), self._color)
+            self._iconBadge.setVisible(True)
+        else:
+            self._iconBadge.setVisible(False)
         self.rearrange()
 
         if self._connector:

--- a/src/main/python/plotlyst/view/widget/graphics/scene.py
+++ b/src/main/python/plotlyst/view/widget/graphics/scene.py
@@ -35,6 +35,7 @@ from plotlyst.core.domain import Node, Diagram, GraphicsItemType, Connector, Pla
 from plotlyst.service.image import LoadedImage
 from plotlyst.view.widget.graphics import NodeItem, CharacterItem, PlaceholderSocketItem, ConnectorItem, \
     AbstractSocketItem, EventItem
+from plotlyst.view.widget.graphics.commands import ItemAdditionCommand
 from plotlyst.view.widget.graphics.items import NoteItem, ImageItem, IconItem, CircleShapedNodeItem
 
 
@@ -273,6 +274,16 @@ class NetworkScene(QGraphicsScene):
     def connectorChangedEvent(self, connector: ConnectorItem):
         self._save()
 
+    def addNodeItem(self, item: NodeItem):
+        self.addItem(item)
+        self._diagram.data.nodes.append(item.node())
+        self._save()
+
+    def removeNodeItem(self, item: NodeItem):
+        self.removeItem(item)
+        self._diagram.data.nodes.remove(item.node())
+        self._save()
+
     @staticmethod
     def toCharacterNode(scenePos: QPointF) -> Node:
         node = Node(scenePos.x(), scenePos.y(), type=GraphicsItemType.CHARACTER, size=60)
@@ -385,6 +396,8 @@ class NetworkScene(QGraphicsScene):
 
         self._diagram.data.nodes.append(item.node())
         self._save()
+
+        self._undoStack.push(ItemAdditionCommand(self, item, scenePos))
 
         return item
 

--- a/src/main/python/plotlyst/view/widget/graphics/scene.py
+++ b/src/main/python/plotlyst/view/widget/graphics/scene.py
@@ -35,7 +35,7 @@ from plotlyst.core.domain import Node, Diagram, GraphicsItemType, Connector, Pla
 from plotlyst.service.image import LoadedImage
 from plotlyst.view.widget.graphics import NodeItem, CharacterItem, PlaceholderSocketItem, ConnectorItem, \
     AbstractSocketItem, EventItem
-from plotlyst.view.widget.graphics.commands import ItemAdditionCommand
+from plotlyst.view.widget.graphics.commands import ItemAdditionCommand, ConnectorAdditionCommand
 from plotlyst.view.widget.graphics.items import NoteItem, ImageItem, IconItem, CircleShapedNodeItem
 
 
@@ -152,6 +152,9 @@ class NetworkScene(QGraphicsScene):
 
         self.addItem(connectorItem)
         self.endLink()
+
+        self._undoStack.push(ConnectorAdditionCommand(self, connectorItem))
+
         sourceNode.setSelected(False)
         connectorItem.setSelected(True)
 
@@ -280,9 +283,17 @@ class NetworkScene(QGraphicsScene):
         self._save()
 
     def removeNodeItem(self, item: NodeItem):
-        self.removeItem(item)
-        self._diagram.data.nodes.remove(item.node())
+        self._removeItem(item)
+
+    def addConnectorItem(self, connectorItem: ConnectorItem):
+        self.addItem(connectorItem)
+        connectorItem.source().addConnector(connectorItem)
+        connectorItem.target().addConnector(connectorItem)
+        self._diagram.data.connectors.append(connectorItem.connector())
         self._save()
+
+    def removeConnectorItem(self, connector: ConnectorItem):
+        self._removeItem(connector)
 
     @staticmethod
     def toCharacterNode(scenePos: QPointF) -> Node:

--- a/src/main/python/plotlyst/view/widget/graphics/scene.py
+++ b/src/main/python/plotlyst/view/widget/graphics/scene.py
@@ -131,7 +131,7 @@ class NetworkScene(QGraphicsScene):
             sourceNode.node().id,
             targetNode.node().id,
             self._connectorPlaceholder.source().angle(), target.angle(),
-            pen=connectorItem.penStyle(), width=connectorItem.penWidth()
+            pen=connectorItem.penStyle(), width=connectorItem.size()
         )
         if connectorItem.icon():
             connector.icon = connectorItem.icon()

--- a/src/main/python/plotlyst/view/widget/graphics/scene.py
+++ b/src/main/python/plotlyst/view/widget/graphics/scene.py
@@ -36,7 +36,7 @@ from plotlyst.service.image import LoadedImage
 from plotlyst.view.widget.graphics import NodeItem, CharacterItem, PlaceholderSocketItem, ConnectorItem, \
     AbstractSocketItem, EventItem
 from plotlyst.view.widget.graphics.commands import ItemAdditionCommand, ItemRemovalCommand
-from plotlyst.view.widget.graphics.items import NoteItem, ImageItem, IconItem, CircleShapedNodeItem
+from plotlyst.view.widget.graphics.items import NoteItem, ImageItem, IconItem, CircleShapedNodeItem, ResizeIconItem
 
 
 @dataclass
@@ -259,6 +259,10 @@ class NetworkScene(QGraphicsScene):
                 self._macroUndo = True
 
         self.itemMoved.emit(item)
+
+    def itemResizedEvent(self, item: ResizeIconItem):
+        if item.posCommandEnabled():
+            self._movedItems.add(item)
 
     def nodeChangedEvent(self, node: Node):
         self._save()

--- a/src/main/python/plotlyst/view/widget/graphics/scene.py
+++ b/src/main/python/plotlyst/view/widget/graphics/scene.py
@@ -25,7 +25,7 @@ from typing import Optional, Dict
 import qtanim
 from PyQt6.QtCore import Qt, pyqtSignal, QPointF, QPoint, QObject
 from PyQt6.QtGui import QTransform, \
-    QKeyEvent, QKeySequence, QCursor, QImage
+    QKeyEvent, QKeySequence, QCursor, QImage, QUndoStack
 from PyQt6.QtWidgets import QGraphicsItem, QGraphicsScene, QGraphicsSceneMouseEvent, QApplication, \
     QGraphicsSceneDragDropEvent
 from overrides import overrides
@@ -54,6 +54,7 @@ class NetworkScene(QGraphicsScene):
     def __init__(self, parent=None):
         super().__init__(parent)
         self._diagram: Optional[Diagram] = None
+        self._undoStack: Optional[QUndoStack] = None
         self._linkMode: bool = False
         self._additionDescriptor: Optional[ItemDescriptor] = None
         self._copyDescriptor: Optional[ItemDescriptor] = None
@@ -61,6 +62,12 @@ class NetworkScene(QGraphicsScene):
 
         self._placeholder: Optional[PlaceholderSocketItem] = None
         self._connectorPlaceholder: Optional[ConnectorItem] = None
+
+    def undoStack(self) -> QUndoStack:
+        return self._undoStack
+
+    def setUndoStack(self, stack: QUndoStack):
+        self._undoStack = stack
 
     def setDiagram(self, diagram: Diagram):
         self._diagram = diagram

--- a/src/main/python/plotlyst/view/widget/graphics/view.py
+++ b/src/main/python/plotlyst/view/widget/graphics/view.py
@@ -38,7 +38,7 @@ from plotlyst.view.common import shadow, tool_btn, frame, ExclusiveOptionalButto
 from plotlyst.view.icons import IconRegistry
 from plotlyst.view.widget.characters import CharacterSelectorMenu
 from plotlyst.view.widget.graphics import CharacterItem, ConnectorItem
-from plotlyst.view.widget.graphics.commands import GraphicsItemCommand
+from plotlyst.view.widget.graphics.commands import GraphicsItemCommand, TextEditingCommand
 from plotlyst.view.widget.graphics.editor import ZoomBar, ConnectorToolbar, TextLineEditorPopup, CharacterToolbar, \
     NoteToolbar, IconItemToolbar
 from plotlyst.view.widget.graphics.items import NodeItem, EventItem, NoteItem, IconItem
@@ -301,7 +301,7 @@ class NetworkGraphicsView(BaseGraphicsView):
 
     def _editEventItem(self, item: EventItem):
         def setText(text: str):
-            item.setText(text)
+            self.undoStack.push(TextEditingCommand(item, text))
 
         popup = TextLineEditorPopup(item.text(), item.textRect(), parent=self)
         font = QFont(item.font())

--- a/src/main/python/plotlyst/view/widget/graphics/view.py
+++ b/src/main/python/plotlyst/view/widget/graphics/view.py
@@ -30,6 +30,7 @@ from PyQt6.QtWidgets import QGraphicsView, QGraphicsItem, QFrame, \
 from overrides import overrides
 from qthandy import sp, incr_icon, vbox
 from qthandy.filter import DragEventFilter
+from qtpy import sip
 
 from plotlyst.common import BLACK_COLOR
 from plotlyst.core.domain import Diagram, GraphicsItemType, Character
@@ -260,6 +261,8 @@ class NetworkGraphicsView(BaseGraphicsView):
         return NetworkScene()
 
     def _selectionChanged(self):
+        if sip.isdeleted(self._scene):
+            return
         if len(self._scene.selectedItems()) == 1:
             self._hideItemToolbar()
             self._showItemToolbar(self._scene.selectedItems()[0])

--- a/src/main/python/plotlyst/view/widget/graphics/view.py
+++ b/src/main/python/plotlyst/view/widget/graphics/view.py
@@ -38,6 +38,7 @@ from plotlyst.view.common import shadow, tool_btn, frame, ExclusiveOptionalButto
 from plotlyst.view.icons import IconRegistry
 from plotlyst.view.widget.characters import CharacterSelectorMenu
 from plotlyst.view.widget.graphics import CharacterItem, ConnectorItem
+from plotlyst.view.widget.graphics.commands import GraphicsItemCommand
 from plotlyst.view.widget.graphics.editor import ZoomBar, ConnectorToolbar, TextLineEditorPopup, CharacterToolbar, \
     NoteToolbar, IconItemToolbar
 from plotlyst.view.widget.graphics.items import NodeItem, EventItem, NoteItem, IconItem
@@ -290,7 +291,8 @@ class NetworkGraphicsView(BaseGraphicsView):
 
     def _editCharacterItem(self, item: CharacterItem):
         def select(character: Character):
-            item.setCharacter(character)
+            command = GraphicsItemCommand(item, item.setCharacter, item.character(), character)
+            self.undoStack.push(command)
 
         popup = self._characterSelectorMenu()
         popup.selected.connect(select)

--- a/src/main/python/plotlyst/view/widget/graphics/view.py
+++ b/src/main/python/plotlyst/view/widget/graphics/view.py
@@ -165,8 +165,8 @@ class NetworkGraphicsView(BaseGraphicsView):
         self.undoStack.setUndoLimit(100)
         self.undoStack.canUndoChanged.connect(self._btnUndo.setEnabled)
         self.undoStack.canRedoChanged.connect(self._btnRedo.setEnabled)
-        self._btnUndo.clicked.connect(self.undoStack.undo)
-        self._btnRedo.clicked.connect(self.undoStack.redo)
+        self._btnUndo.clicked.connect(self._undo)
+        self._btnRedo.clicked.connect(self._redo)
         self._scene.setUndoStack(self.undoStack)
 
         self._connectorEditor: Optional[ConnectorToolbar] = None
@@ -354,3 +354,11 @@ class NetworkGraphicsView(BaseGraphicsView):
 
     def _characterSelectorMenu(self) -> CharacterSelectorMenu:
         pass
+
+    def _undo(self):
+        self._hideItemToolbar()
+        self.undoStack.undo()
+
+    def _redo(self):
+        self._hideItemToolbar()
+        self.undoStack.redo()

--- a/src/main/python/plotlyst/view/widget/graphics/view.py
+++ b/src/main/python/plotlyst/view/widget/graphics/view.py
@@ -31,9 +31,11 @@ from overrides import overrides
 from qthandy import sp, incr_icon, vbox
 from qthandy.filter import DragEventFilter
 
+from plotlyst.common import BLACK_COLOR
 from plotlyst.core.domain import Diagram, GraphicsItemType, Character
 from plotlyst.view.common import shadow, tool_btn, frame, ExclusiveOptionalButtonGroup, \
     TooltipPositionEventFilter, label
+from plotlyst.view.icons import IconRegistry
 from plotlyst.view.widget.characters import CharacterSelectorMenu
 from plotlyst.view.widget.graphics import CharacterItem, ConnectorItem
 from plotlyst.view.widget.graphics.editor import ZoomBar, ConnectorToolbar, TextLineEditorPopup, CharacterToolbar, \
@@ -54,7 +56,6 @@ class BaseGraphicsView(QGraphicsView):
         self.setRenderHint(QPainter.RenderHint.Antialiasing)
         self.setRenderHint(QPainter.RenderHint.SmoothPixmapTransform)
         self.setRenderHint(QPainter.RenderHint.LosslessImageRendering)
-        self.undoStack = QUndoStack()
 
     @overrides
     def mousePressEvent(self, event: QMouseEvent) -> None:
@@ -151,6 +152,16 @@ class NetworkGraphicsView(BaseGraphicsView):
         sp(self._controlsNavBar).h_max()
         shadow(self._controlsNavBar)
         vbox(self._controlsNavBar, 5, 6)
+
+        self._btnUndo = tool_btn(IconRegistry.from_name('mdi.undo', BLACK_COLOR), transparent_=True, tooltip='Undo')
+        self._btnUndo.setDisabled(True)
+        self._btnRedo = tool_btn(IconRegistry.from_name('mdi.redo', BLACK_COLOR), transparent_=True, tooltip='Redo')
+        self._btnRedo.setDisabled(True)
+        self.undoStack = QUndoStack()
+        self.undoStack.canUndoChanged.connect(self._btnUndo.setEnabled)
+        self.undoStack.canRedoChanged.connect(self._btnRedo.setEnabled)
+        self._btnUndo.clicked.connect(self.undoStack.undo)
+        self._btnRedo.clicked.connect(self.undoStack.redo)
 
         self._connectorEditor: Optional[ConnectorToolbar] = None
         self._characterEditor: Optional[CharacterToolbar] = None

--- a/src/main/python/plotlyst/view/widget/graphics/view.py
+++ b/src/main/python/plotlyst/view/widget/graphics/view.py
@@ -166,6 +166,7 @@ class NetworkGraphicsView(BaseGraphicsView):
         self.undoStack.canRedoChanged.connect(self._btnRedo.setEnabled)
         self._btnUndo.clicked.connect(self.undoStack.undo)
         self._btnRedo.clicked.connect(self.undoStack.redo)
+        self._scene.setUndoStack(self.undoStack)
 
         self._connectorEditor: Optional[ConnectorToolbar] = None
         self._characterEditor: Optional[CharacterToolbar] = None

--- a/src/main/python/plotlyst/view/widget/graphics/view.py
+++ b/src/main/python/plotlyst/view/widget/graphics/view.py
@@ -24,7 +24,7 @@ from typing import Optional
 import qtanim
 from PyQt6.QtCore import Qt, QTimer
 from PyQt6.QtGui import QPainter, QWheelEvent, QMouseEvent, QColor, QIcon, QResizeEvent, QNativeGestureEvent, QFont, \
-    QUndoStack
+    QUndoStack, QKeySequence
 from PyQt6.QtWidgets import QGraphicsView, QGraphicsItem, QFrame, \
     QToolButton, QApplication, QWidget
 from overrides import overrides
@@ -154,10 +154,13 @@ class NetworkGraphicsView(BaseGraphicsView):
         vbox(self._controlsNavBar, 5, 6)
 
         self._btnUndo = tool_btn(IconRegistry.from_name('mdi.undo', BLACK_COLOR), transparent_=True, tooltip='Undo')
+        self._btnUndo.setShortcut(QKeySequence.StandardKey.Undo)
         self._btnUndo.setDisabled(True)
         self._btnRedo = tool_btn(IconRegistry.from_name('mdi.redo', BLACK_COLOR), transparent_=True, tooltip='Redo')
+        self._btnRedo.setShortcut(QKeySequence.StandardKey.Redo)
         self._btnRedo.setDisabled(True)
         self.undoStack = QUndoStack()
+        self.undoStack.setUndoLimit(100)
         self.undoStack.canUndoChanged.connect(self._btnUndo.setEnabled)
         self.undoStack.canRedoChanged.connect(self._btnRedo.setEnabled)
         self._btnUndo.clicked.connect(self.undoStack.undo)

--- a/src/main/python/plotlyst/view/widget/graphics/view.py
+++ b/src/main/python/plotlyst/view/widget/graphics/view.py
@@ -23,7 +23,8 @@ from typing import Optional
 
 import qtanim
 from PyQt6.QtCore import Qt, QTimer
-from PyQt6.QtGui import QPainter, QWheelEvent, QMouseEvent, QColor, QIcon, QResizeEvent, QNativeGestureEvent, QFont
+from PyQt6.QtGui import QPainter, QWheelEvent, QMouseEvent, QColor, QIcon, QResizeEvent, QNativeGestureEvent, QFont, \
+    QUndoStack
 from PyQt6.QtWidgets import QGraphicsView, QGraphicsItem, QFrame, \
     QToolButton, QApplication, QWidget
 from overrides import overrides
@@ -53,6 +54,7 @@ class BaseGraphicsView(QGraphicsView):
         self.setRenderHint(QPainter.RenderHint.Antialiasing)
         self.setRenderHint(QPainter.RenderHint.SmoothPixmapTransform)
         self.setRenderHint(QPainter.RenderHint.LosslessImageRendering)
+        self.undoStack = QUndoStack()
 
     @overrides
     def mousePressEvent(self, event: QMouseEvent) -> None:

--- a/src/main/python/plotlyst/view/widget/story_map.py
+++ b/src/main/python/plotlyst/view/widget/story_map.py
@@ -196,7 +196,7 @@ class EventsMindMapView(NetworkGraphicsView):
 
     @overrides
     def _editNoteItem(self, item: NoteItem):
-        popup = TextNoteEditorPopup(item, parent=self)
+        popup = TextNoteEditorPopup(self.undoStack, item, parent=self)
         font = QApplication.font()
         popup.setFont(font)
 

--- a/src/main/python/plotlyst/view/widget/story_map.py
+++ b/src/main/python/plotlyst/view/widget/story_map.py
@@ -24,6 +24,7 @@ from PyQt6.QtGui import QImage
 from PyQt6.QtGui import QShowEvent
 from PyQt6.QtWidgets import QApplication
 from overrides import overrides
+from qthandy import line
 
 from plotlyst.common import BLACK_COLOR
 from plotlyst.core.client import json_client
@@ -92,6 +93,10 @@ class EventsMindMapView(NetworkGraphicsView):
             IconRegistry.from_name('mdi.emoticon-outline'), 'Add new icon', GraphicsItemType.ICON)
         self._btnAddImage = self._newControlButton(IconRegistry.image_icon(), 'Add new image',
                                                    GraphicsItemType.IMAGE)
+
+        self._controlsNavBar.layout().addWidget(line())
+        self._controlsNavBar.layout().addWidget(self._btnUndo)
+        self._controlsNavBar.layout().addWidget(self._btnRedo)
         # self._btnAddSticker = self._newControlButton(IconRegistry.from_name('mdi6.sticker-circle-outline'),
         #                                              'Add new sticker',
         #                                              GraphicsItemType.COMMENT)
@@ -108,17 +113,17 @@ class EventsMindMapView(NetworkGraphicsView):
         # self._stickerEditor = StickerEditor(self)
         # self._stickerEditor.setVisible(False)
 
-        self._itemEditor = EventItemToolbar(self)
+        self._itemEditor = EventItemToolbar(self.undoStack, self)
         self._itemEditor.setVisible(False)
 
-        self._connectorEditor = ConnectorToolbar(self)
+        self._connectorEditor = ConnectorToolbar(self.undoStack, self)
         self._connectorEditor.setVisible(False)
-        self._characterEditor = CharacterToolbar(self)
+        self._characterEditor = CharacterToolbar(self.undoStack, self)
         self._characterEditor.changeCharacter.connect(self._editCharacterItem)
         self._characterEditor.setVisible(False)
-        self._noteEditor = NoteToolbar(self)
+        self._noteEditor = NoteToolbar(self.undoStack, self)
         self._noteEditor.setVisible(False)
-        self._iconEditor = IconItemToolbar(self)
+        self._iconEditor = IconItemToolbar(self.undoStack, self)
         self._iconEditor.setVisible(False)
 
         self._arrangeSideBars()


### PR DESCRIPTION
- [x] connector
- [x] tooltip
- [x] movement
- [x] movement together
- [x] icon
- [x] color
- [x] note item
  - [x] transparent
  - [x] settext
  - [x] resize
- [x] character
  - [x] size
  - [x] text
  - [x] character
 - [x] uplimit
 - [x] icon
   - [x] size
   - [x] icon change
 - [x] event
   - [x] font settings
   - [x] size
   - [x] icon, color
   - [x] type
   - [x] text
 - [x] shortcut
 - [ ] image
   - [x] resize
   - [ ] new image
 - [x] link/unlink
 - [x] add new item
 - [x] nodes registry
 - [x] remove connector
 - [x] remove item
 - [x] remove selected items and connectors
 - [x] hide toolbars on undo/redo