### PR TITLE
Track fantasy conceits

### DIFF
--- a/src/main/python/plotlyst/core/domain.py
+++ b/src/main/python/plotlyst/core/domain.py
@@ -2099,6 +2099,7 @@ class WorldBuildingEntityElementType(Enum):
     Section = 8
     Highlight = 9
     Main_Section = 10
+    Conceits = 11
 
 
 @dataclass
@@ -2146,6 +2147,50 @@ class WorldBuildingEntity:
     @overrides
     def __eq__(self, other: 'WorldBuildingEntity'):
         if isinstance(other, WorldBuildingEntity):
+            return self.id == other.id
+        return False
+
+    @overrides
+    def __hash__(self):
+        return hash(str(self.id))
+
+
+class WorldConceitType(Enum):
+    Geography = 'geography'
+    Biology = 'biology'
+    Magic = 'magic'
+    Metaphysics = 'metaphysics'
+    Technology = 'technology'
+    Culture = 'culture'
+
+    def icon(self) -> str:
+        if self == WorldConceitType.Geography:
+            return 'ph.globe-bold'
+        elif self == WorldConceitType.Biology:
+            return 'mdi.dna'
+        elif self == WorldConceitType.Magic:
+            return 'ei.magic'
+        elif self == WorldConceitType.Metaphysics:
+            return 'mdi.eye-circle-outline'
+        elif self == WorldConceitType.Technology:
+            return 'ei.cogs'
+        elif self == WorldConceitType.Culture:
+            return 'mdi.vector-circle'
+
+
+@dataclass
+class WorldConceit:
+    name: str
+    type: WorldConceitType
+    id: uuid.UUID = field(default_factory=uuid.uuid4)
+    text: str = field(default='', metadata=config(exclude=exclude_if_empty))
+    icon: str = ''
+    icon_color: str = 'black'
+    conceits: List['WorldConceit'] = field(default_factory=list, metadata=config(exclude=exclude_if_empty))
+
+    @overrides
+    def __eq__(self, other: 'WorldConceit'):
+        if isinstance(other, WorldConceit):
             return self.id == other.id
         return False
 
@@ -2302,6 +2347,7 @@ class WorldBuilding:
     root_entity: WorldBuildingEntity = field(default_factory=worldbuilding_root)
     glossary: Dict[str, GlossaryItem] = field(default_factory=dict)
     maps: List[WorldBuildingMap] = field(default_factory=default_maps)
+    conceits: List[WorldConceit] = field(default_factory=list, metadata=config(exclude=exclude_if_empty))
 
 
 @dataclass

--- a/src/main/python/plotlyst/core/domain.py
+++ b/src/main/python/plotlyst/core/domain.py
@@ -2186,7 +2186,7 @@ class WorldConceit:
     text: str = field(default='', metadata=config(exclude=exclude_if_empty))
     icon: str = ''
     icon_color: str = 'black'
-    conceits: List['WorldConceit'] = field(default_factory=list, metadata=config(exclude=exclude_if_empty))
+    children: List['WorldConceit'] = field(default_factory=list, metadata=config(exclude=exclude_if_empty))
 
     @overrides
     def __eq__(self, other: 'WorldConceit'):

--- a/src/main/python/plotlyst/core/domain.py
+++ b/src/main/python/plotlyst/core/domain.py
@@ -2184,8 +2184,8 @@ class WorldConceit:
     type: WorldConceitType
     id: uuid.UUID = field(default_factory=uuid.uuid4)
     text: str = field(default='', metadata=config(exclude=exclude_if_empty))
-    icon: str = ''
-    icon_color: str = 'black'
+    icon: str = field(default='', metadata=config(exclude=exclude_if_empty))
+    icon_color: str = field(default='', metadata=config(exclude=exclude_if_empty))
     children: List['WorldConceit'] = field(default_factory=list, metadata=config(exclude=exclude_if_empty))
 
     @overrides

--- a/src/main/python/plotlyst/env.py
+++ b/src/main/python/plotlyst/env.py
@@ -69,6 +69,9 @@ class AppEnvironment:
     def is_prod(self) -> bool:
         return self._mode == AppMode.PROD
 
+    def is_plus(self) -> bool:
+        return True
+
     def test_env(self) -> bool:
         if os.getenv('PLOTLYST_TEST_ENV'):
             return True

--- a/src/main/python/plotlyst/view/icons.py
+++ b/src/main/python/plotlyst/view/icons.py
@@ -711,6 +711,10 @@ class IconRegistry:
         return IconRegistry.from_name('ei.refresh', color=color)
 
     @staticmethod
+    def dot_icon(**kwargs) -> QIcon:
+        return IconRegistry.from_name('msc.debug-stackframe-dot', **kwargs)
+
+    @staticmethod
     def from_selection_item(item: SelectionItem) -> QIcon:
         return IconRegistry.from_name(item.icon, item.icon_color)
 

--- a/src/main/python/plotlyst/view/widget/world/conceit.py
+++ b/src/main/python/plotlyst/view/widget/world/conceit.py
@@ -43,7 +43,8 @@ class ConceitBubble(TextEditBubbleWidget):
 
         self._removalEnabled = True
 
-        self._title.setIcon(IconRegistry.from_name(self.conceit.icon, '#510442'))
+        icon = self.conceit.icon if self.conceit.icon else self.conceit.type.icon()
+        self._title.setIcon(IconRegistry.from_name(icon, '#510442'))
         self._title.setText(self.conceit.name)
         self._title.lineEdit.textEdited.connect(self._titleEdited)
         self._textedit.setPlaceholderText('An element of wonder that deviates from our world')
@@ -80,6 +81,7 @@ class ConceitNode(ItemBasedNode):
         self._actionChangeIcon.setVisible(False)
         self._btnAdd.clicked.connect(self.added)
         self.refresh()
+        self._icon.setVisible(True)
 
     @overrides
     def item(self) -> WorldConceit:
@@ -125,6 +127,7 @@ class ConceitTypeNode(ItemBasedNode):
 class ConceitsTreeView(ItemBasedTreeView):
     CONCEIT_ENTITY_MIMETYPE = 'application/world-conceit'
     conceitSelected = pyqtSignal(WorldConceit)
+    rootSelected = pyqtSignal()
     conceitDeleted = pyqtSignal(WorldConceit)
 
     def __init__(self, novel: Novel, parent=None):
@@ -183,7 +186,10 @@ class ConceitsTreeView(ItemBasedTreeView):
 
     @overrides
     def _emitSelectionChanged(self, conceit: WorldConceit):
-        self.conceitSelected.emit(conceit)
+        if conceit == self._root:
+            self.rootSelected.emit()
+        else:
+            self.conceitSelected.emit(conceit)
 
     @overrides
     def _mimeType(self) -> str:

--- a/src/main/python/plotlyst/view/widget/world/conceit.py
+++ b/src/main/python/plotlyst/view/widget/world/conceit.py
@@ -45,7 +45,8 @@ class ConceitBubble(TextEditBubbleWidget):
         self._removalEnabled = True
 
         icon = self.conceit.icon if self.conceit.icon else self.conceit.type.icon()
-        self._title.setIcon(IconRegistry.from_name(icon, '#510442'))
+        color = self.conceit.icon_color if self.conceit.icon_color else '#510442'
+        self._title.setIcon(IconRegistry.from_name(icon, color))
         self._title.setText(self.conceit.name)
         self._title.lineEdit.textEdited.connect(self._titleEdited)
         self._title.iconChanged.connect(self._iconChanged)
@@ -70,6 +71,9 @@ class ConceitBubble(TextEditBubbleWidget):
 
     def _iconChanged(self, icon: str, color: str):
         self.conceit.icon = icon
+        if color == 'black' or color == '#000000':
+            color = '#510442'
+            self._title.setIcon(IconRegistry.from_name(icon, color))
         self.conceit.icon_color = color
         self.iconChanged.emit()
 

--- a/src/main/python/plotlyst/view/widget/world/conceit.py
+++ b/src/main/python/plotlyst/view/widget/world/conceit.py
@@ -40,6 +40,8 @@ class ConceitBubble(TextEditBubbleWidget):
         super().__init__(parent, titleEditable=True, titleMaxWidth=150)
         self.conceit = conceit
 
+        self._removalEnabled = True
+
         self._title.setIcon(IconRegistry.from_name(self.conceit.icon, '#510442'))
         self._title.setText(self.conceit.name)
         self._title.lineEdit.textEdited.connect(self._titleEdited)

--- a/src/main/python/plotlyst/view/widget/world/conceit.py
+++ b/src/main/python/plotlyst/view/widget/world/conceit.py
@@ -36,9 +36,10 @@ from plotlyst.view.widget.tree import ItemBasedNode, TreeSettings, ItemBasedTree
 class ConceitBubble(TextEditBubbleWidget):
     nameEdited = pyqtSignal()
     textChanged = pyqtSignal()
+    iconChanged = pyqtSignal()
 
     def __init__(self, conceit: WorldConceit, parent=None):
-        super().__init__(parent, titleEditable=True, titleMaxWidth=150)
+        super().__init__(parent, titleEditable=True, titleMaxWidth=150, iconEditable=True)
         self.conceit = conceit
 
         self._removalEnabled = True
@@ -47,6 +48,7 @@ class ConceitBubble(TextEditBubbleWidget):
         self._title.setIcon(IconRegistry.from_name(icon, '#510442'))
         self._title.setText(self.conceit.name)
         self._title.lineEdit.textEdited.connect(self._titleEdited)
+        self._title.iconChanged.connect(self._iconChanged)
         self._textedit.setPlaceholderText('An element of wonder that deviates from our world')
         self._textedit.setStyleSheet('''
             QTextEdit {
@@ -57,7 +59,6 @@ class ConceitBubble(TextEditBubbleWidget):
             }
         ''')
         self._textedit.setText(self.conceit.text)
-        self._textedit.textChanged.connect(self._textChanged)
 
     def _titleEdited(self, text: str):
         self.conceit.name = text
@@ -66,6 +67,11 @@ class ConceitBubble(TextEditBubbleWidget):
     def _textChanged(self):
         self.conceit.text = self._textedit.toPlainText()
         self.textChanged.emit()
+
+    def _iconChanged(self, icon: str, color: str):
+        self.conceit.icon = icon
+        self.conceit.icon_color = color
+        self.iconChanged.emit()
 
 
 class ConceitNode(ItemBasedNode):
@@ -91,7 +97,7 @@ class ConceitNode(ItemBasedNode):
     def refresh(self):
         self._lblTitle.setText(self._conceit.name if self._conceit.name else 'Conceit')
         if self._conceit.icon:
-            self._icon.setIcon(IconRegistry.from_name(self._conceit.icon))
+            self._icon.setIcon(IconRegistry.from_name(self._conceit.icon, self._conceit.icon_color))
         else:
             self._icon.setIcon(IconRegistry.dot_icon())
 

--- a/src/main/python/plotlyst/view/widget/world/conceit.py
+++ b/src/main/python/plotlyst/view/widget/world/conceit.py
@@ -1,0 +1,155 @@
+"""
+Plotlyst
+Copyright (C) 2021-2024  Zsolt Kovari
+
+This file is part of Plotlyst.
+
+Plotlyst is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Plotlyst is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+from functools import partial
+from typing import Optional, List, Dict
+
+from PyQt6.QtCore import pyqtSignal
+from overrides import overrides
+from qthandy import clear_layout, vspacer
+
+from plotlyst.common import recursive
+from plotlyst.core.domain import WorldConceit, WorldBuilding, WorldConceitType, Novel
+from plotlyst.service.persistence import RepositoryPersistenceManager
+from plotlyst.view.icons import IconRegistry
+from plotlyst.view.widget.tree import ItemBasedNode, TreeSettings, ItemBasedTreeView, ContainerNode
+
+
+class ConceitNode(ItemBasedNode):
+    added = pyqtSignal()
+
+    def __init__(self, conceit: WorldConceit, parent=None, readOnly: bool = False,
+                 settings: Optional[TreeSettings] = None):
+        super().__init__(conceit.name, parent=parent, settings=settings)
+        self._conceit = conceit
+        self.setPlusButtonEnabled(not readOnly)
+        self.setMenuEnabled(not readOnly)
+        self.setTranslucentIconEnabled(True)
+        self._actionChangeIcon.setVisible(False)
+        self._btnAdd.clicked.connect(self.added)
+        self.refresh()
+
+    @overrides
+    def item(self) -> WorldConceit:
+        return self._conceit
+
+    @overrides
+    def refresh(self):
+        self._lblTitle.setText(self._conceit.name if self._conceit.name else 'Conceit')
+        if self._conceit.icon:
+            self._icon.setIcon(IconRegistry.from_name(self._conceit.icon))
+        else:
+            self._icon.setIcon(IconRegistry.dot_icon())
+
+    @overrides
+    def _iconChanged(self, iconName: str, iconColor: str):
+        pass
+
+
+# class ConceitRootNode(ContainerNode):
+#     def __init__(self, parent=None):
+#         super().__init__('Conceits', parent, readOnly=True)
+
+
+class ConceitTypeNode(ContainerNode):
+    def __init__(self, conceitType: WorldConceitType, parent=None):
+        super().__init__(conceitType.name, IconRegistry.from_name(conceitType.icon()), parent, readOnly=True)
+
+
+class ConceitsTreeView(ItemBasedTreeView):
+    CONCEIT_ENTITY_MIMETYPE = 'application/world-conceit'
+    conceitSelected = pyqtSignal(WorldConceit)
+    conceitDeleted = pyqtSignal(WorldConceit)
+
+    def __init__(self, novel: Novel, parent=None):
+        super().__init__(parent)
+        self._novel = novel
+        self._world: WorldBuilding = novel.world
+        self._readOnly = False
+        self._settings = TreeSettings(bg_color='#ede0d4',
+                                      action_buttons_color='#510442',
+                                      selection_bg_color='#DABFA7',
+                                      hover_bg_color='#E3D0BD',
+                                      selection_text_color='#510442')
+        self._centralWidget.setStyleSheet(f'#centralWidget {{background: {self._settings.bg_color};}}')
+
+        self.repo = RepositoryPersistenceManager.instance()
+
+        self.refresh()
+
+    def refresh(self):
+        def addChildWdg(parent: WorldConceit, child: WorldConceit):
+            childWdg = self._initNode(child)
+            self._nodes[parent].addChild(childWdg)
+
+        self.clearSelection()
+        self._nodes.clear()
+        clear_layout(self._centralWidget)
+
+        rootNode = ContainerNode('Conceits', readOnly=True)
+        self._centralWidget.layout().addWidget(rootNode)
+
+        typeNodes: Dict[WorldConceitType, ContainerNode] = {}
+        for conceitType in WorldConceitType:
+            typeNode = ContainerNode(conceitType.name, IconRegistry.from_name(conceitType.icon()), readOnly=True)
+            typeNodes[conceitType] = typeNode
+            rootNode.addChild(typeNode)
+
+        for conceit in self._world.conceits:
+            node = self._initNode(conceit)
+            typeNodes[conceit.type].addChild(node)
+            recursive(conceit, lambda parent: parent.children, addChildWdg)
+        self._centralWidget.layout().addWidget(vspacer())
+
+        for node in typeNodes.values():
+            if not node.childrenWidgets():
+                node.setVisible(False)
+
+    @overrides
+    def _emitSelectionChanged(self, conceit: WorldConceit):
+        self.conceitSelected.emit(conceit)
+
+    @overrides
+    def _mimeType(self) -> str:
+        return self.CONCEIT_ENTITY_MIMETYPE
+
+    @overrides
+    def _topLevelItems(self) -> List[WorldConceit]:
+        return self._world.conceits
+
+    @overrides
+    def _node(self, conceit: WorldConceit) -> ConceitNode:
+        return ConceitNode(conceit, settings=self._settings)
+
+    @overrides
+    def _save(self):
+        self.repo.update_world(self._novel)
+
+    @overrides
+    def _initNode(self, conceit: WorldConceit) -> ConceitNode:
+        node = ConceitNode(conceit, readOnly=self._readOnly, settings=self._settings)
+        self._nodes[conceit] = node
+        node.selectionChanged.connect(partial(self._selectionChanged, node))
+        # node.added.connect(partial(self._addLocationUnder, node))
+        # node.deleted.connect(partial(self._deleteLocation, node))
+
+        # if not self._readOnly:
+        #     self._enhanceWithDnd(node)
+
+        return node

--- a/src/main/python/plotlyst/view/widget/world/conceit.py
+++ b/src/main/python/plotlyst/view/widget/world/conceit.py
@@ -128,6 +128,7 @@ class ConceitsTreeView(ItemBasedTreeView):
     CONCEIT_ENTITY_MIMETYPE = 'application/world-conceit'
     conceitSelected = pyqtSignal(WorldConceit)
     rootSelected = pyqtSignal()
+    conceitTypeSelected = pyqtSignal(WorldConceitType)
     conceitDeleted = pyqtSignal(WorldConceit)
 
     def __init__(self, novel: Novel, parent=None):
@@ -188,6 +189,8 @@ class ConceitsTreeView(ItemBasedTreeView):
     def _emitSelectionChanged(self, conceit: WorldConceit):
         if conceit == self._root:
             self.rootSelected.emit()
+        elif isinstance(self._nodes[conceit], ConceitTypeNode):
+            self.conceitTypeSelected.emit(conceit.type)
         else:
             self.conceitSelected.emit(conceit)
 

--- a/src/main/python/plotlyst/view/widget/world/editor.py
+++ b/src/main/python/plotlyst/view/widget/world/editor.py
@@ -691,6 +691,7 @@ class ConceitsElementEditor(WorldBuildingEntityElementWidget):
         self._wdgTree = ConceitsTreeView(novel)
         self._wdgTree.rootSelected.connect(self.refresh)
         self._wdgTree.conceitSelected.connect(self._conceitSelected)
+        self._wdgTree.conceitTypeSelected.connect(self._conceitTypeSelected)
         self._wdgTree.conceitDeleted.connect(self._conceitNodeDeleted)
         self._wdgDisplay = QWidget()
         flow(self._wdgDisplay, 10, 8)
@@ -795,6 +796,13 @@ class ConceitsElementEditor(WorldBuildingEntityElementWidget):
         for conceit in conceit.children:
             bubble = self._initBubble(conceit)
             self._wdgDisplay.layout().addWidget(bubble)
+
+    def _conceitTypeSelected(self, conceitType: WorldConceitType):
+        clear_layout(self._wdgDisplay)
+        for conceit in self.novel.world.conceits:
+            if conceit.type == conceitType:
+                bubble = self._initBubble(conceit)
+                self._wdgDisplay.layout().addWidget(bubble)
 
     def _conceitNodeDeleted(self, conceit: WorldConceit):
         for i in range(self._wdgDisplay.layout().count()):

--- a/src/main/python/plotlyst/view/widget/world/editor.py
+++ b/src/main/python/plotlyst/view/widget/world/editor.py
@@ -689,6 +689,7 @@ class ConceitsElementEditor(WorldBuildingEntityElementWidget):
         self._wdgEditor.layout().addWidget(self._splitter)
 
         self._wdgTree = ConceitsTreeView(novel)
+        self._wdgTree.conceitDeleted.connect(self._conceitNodeDeleted)
         self._wdgDisplay = QWidget()
         flow(self._wdgDisplay, 10, 8)
         self._splitter.addWidget(self._wdgTree)
@@ -786,6 +787,14 @@ class ConceitsElementEditor(WorldBuildingEntityElementWidget):
 
         self._wdgTree.refresh()
         self.save()
+
+    def _conceitNodeDeleted(self, conceit: WorldConceit):
+        for i in range(self._wdgDisplay.layout().count()):
+            wdg = self._wdgDisplay.layout().itemAt(i).widget()
+            if wdg and isinstance(wdg, ConceitBubble):
+                if wdg.conceit == conceit:
+                    fade_out_and_gc(self._wdgDisplay, wdg)
+                    return
 
 
 class SectionElementEditor(WorldBuildingEntityElementWidget):

--- a/src/main/python/plotlyst/view/widget/world/editor.py
+++ b/src/main/python/plotlyst/view/widget/world/editor.py
@@ -32,7 +32,7 @@ from qthandy import vspacer, clear_layout, transparent, vbox, margins, hbox, sp,
     grid, flow, spacer, line, incr_icon, gc, translucent, incr_font
 from qthandy.filter import OpacityEventFilter, VisibilityToggleEventFilter, DisabledClickEventFilter, DragEventFilter, \
     DropEventFilter
-from qtmenu import MenuWidget
+from qtmenu import MenuWidget, ActionTooltipDisplayMode
 from qttextedit.ops import Heading2Operation, Heading3Operation, InsertListOperation, InsertNumberedListOperation, \
     InsertDividerOperation
 
@@ -957,6 +957,15 @@ class MainBlockAdditionMenu(MenuWidget):
                               slot=lambda: self.newBlockSelected.emit(WorldBuildingEntityElementType.Image)))
         self.addAction(action('Timeline', IconRegistry.from_name('mdi.timeline'),
                               slot=lambda: self.newBlockSelected.emit(WorldBuildingEntityElementType.Timeline)))
+
+        if app_env.is_plus():
+            otherMenu = MenuWidget()
+            otherMenu.setTooltipDisplayMode(ActionTooltipDisplayMode.DISPLAY_UNDER)
+            tooltip = "Track fantasy elements that deviate from our world, introducing a sense of wonder into the story"
+            otherMenu.addAction(action('Fantasy conceits', IconRegistry.from_name('ei.magic'), tooltip=tooltip))
+            otherMenu.setTitle('Other')
+            self.addSeparator()
+            self.addMenu(otherMenu)
 
 
 class SideBlockAdditionMenu(MenuWidget):

--- a/src/main/python/plotlyst/view/widget/world/editor.py
+++ b/src/main/python/plotlyst/view/widget/world/editor.py
@@ -39,7 +39,7 @@ from qttextedit.ops import Heading2Operation, Heading3Operation, InsertListOpera
 from plotlyst.common import RELAXED_WHITE_COLOR
 from plotlyst.core.domain import Novel, WorldBuildingEntity, WorldBuildingEntityElement, WorldBuildingEntityElementType, \
     BackstoryEvent, Variable, VariableType, \
-    Topic, Location, WorldConceitType
+    Topic, Location, WorldConceitType, WorldConceit
 from plotlyst.env import app_env
 from plotlyst.service.image import upload_image, load_image
 from plotlyst.service.persistence import RepositoryPersistenceManager
@@ -51,7 +51,7 @@ from plotlyst.view.style.text import apply_text_color
 from plotlyst.view.widget.button import DotsMenuButton
 from plotlyst.view.widget.display import Icon, PopupDialog, DotsDragIcon
 from plotlyst.view.widget.input import AutoAdjustableTextEdit, AutoAdjustableLineEdit, MarkdownPopupTextEditorToolbar, \
-    SearchField
+    SearchField, TextEditBubbleWidget
 from plotlyst.view.widget.timeline import TimelineWidget, BackstoryCard, TimelineTheme
 from plotlyst.view.widget.utility import IconSelectorDialog
 from plotlyst.view.widget.world._topics import ecological_topics, cultural_topics, historical_topics, \
@@ -672,6 +672,15 @@ class TimelineElementEditor(WorldBuildingEntityElementWidget):
         self.btnDrag.raise_()
 
 
+class ConceitBubble(TextEditBubbleWidget):
+    def __init__(self, conceit: WorldConceit, parent=None):
+        super().__init__(parent)
+        self.conceit = conceit
+
+        self._title.setIcon(IconRegistry.from_name(self.conceit.icon, '#510442'))
+        self._title.setText(self.conceit.name)
+
+
 class ConceitsElementEditor(WorldBuildingEntityElementWidget):
     def __init__(self, novel: Novel, element: WorldBuildingEntityElement, parent=None):
         super().__init__(novel, element, parent)
@@ -728,11 +737,17 @@ class ConceitsElementEditor(WorldBuildingEntityElementWidget):
     def _showMenu(self):
         menu = MenuWidget()
         for conceitType in WorldConceitType:
-            action_ = action(conceitType.name, IconRegistry.from_name(conceitType.icon()))
+            action_ = action(conceitType.name, IconRegistry.from_name(conceitType.icon()),
+                             slot=partial(self._addNewConceit, conceitType))
             incr_font(action_, 2)
             menu.addAction(action_)
 
         menu.exec()
+
+    def _addNewConceit(self, conceitType: WorldConceitType):
+        conceit = WorldConceit('Conceit', type=conceitType, icon=conceitType.icon())
+        bubble = ConceitBubble(conceit)
+        self._wdgDisplay.layout().addWidget(bubble)
 
 
 class SectionElementEditor(WorldBuildingEntityElementWidget):

--- a/src/main/python/plotlyst/view/widget/world/editor.py
+++ b/src/main/python/plotlyst/view/widget/world/editor.py
@@ -741,7 +741,7 @@ class ConceitsElementEditor(WorldBuildingEntityElementWidget):
     @overrides
     def resizeEvent(self, event: QResizeEvent) -> None:
         super().resizeEvent(event)
-        self._wdgEditor.updateGeometry()
+        self._wdgDisplay.updateGeometry()
 
     def refresh(self):
         clear_layout(self._wdgDisplay)
@@ -773,10 +773,18 @@ class ConceitsElementEditor(WorldBuildingEntityElementWidget):
         bubble = ConceitBubble(conceit)
         bubble.nameEdited.connect(partial(self._conceitNameChanged, conceit))
         bubble.textChanged.connect(self.save)
+        bubble.removed.connect(partial(self._conceitRemoved, bubble))
         return bubble
 
     def _conceitNameChanged(self, conceit: WorldConceit):
         self._wdgTree.updateItem(conceit)
+        self.save()
+
+    def _conceitRemoved(self, bubble: ConceitBubble):
+        self.novel.world.conceits.remove(bubble.conceit)
+        fade_out_and_gc(self._wdgDisplay, bubble)
+
+        self._wdgTree.refresh()
         self.save()
 
 

--- a/src/main/python/plotlyst/view/widget/world/editor.py
+++ b/src/main/python/plotlyst/view/widget/world/editor.py
@@ -689,6 +689,8 @@ class ConceitsElementEditor(WorldBuildingEntityElementWidget):
         self._wdgEditor.layout().addWidget(self._splitter)
 
         self._wdgTree = ConceitsTreeView(novel)
+        self._wdgTree.rootSelected.connect(self.refresh)
+        self._wdgTree.conceitSelected.connect(self._conceitSelected)
         self._wdgTree.conceitDeleted.connect(self._conceitNodeDeleted)
         self._wdgDisplay = QWidget()
         flow(self._wdgDisplay, 10, 8)
@@ -761,7 +763,7 @@ class ConceitsElementEditor(WorldBuildingEntityElementWidget):
         menu.exec()
 
     def _addNewConceit(self, conceitType: WorldConceitType):
-        conceit = WorldConceit('Conceit', type=conceitType, icon=conceitType.icon())
+        conceit = WorldConceit('Conceit', type=conceitType)
         bubble = self._initBubble(conceit)
         self._wdgDisplay.layout().addWidget(bubble)
         fade_in(bubble)
@@ -787,6 +789,12 @@ class ConceitsElementEditor(WorldBuildingEntityElementWidget):
 
         self._wdgTree.refresh()
         self.save()
+
+    def _conceitSelected(self, conceit: WorldConceit):
+        clear_layout(self._wdgDisplay)
+        for conceit in conceit.children:
+            bubble = self._initBubble(conceit)
+            self._wdgDisplay.layout().addWidget(bubble)
 
     def _conceitNodeDeleted(self, conceit: WorldConceit):
         for i in range(self._wdgDisplay.layout().count()):

--- a/src/main/python/plotlyst/view/widget/world/editor.py
+++ b/src/main/python/plotlyst/view/widget/world/editor.py
@@ -674,23 +674,31 @@ class TimelineElementEditor(WorldBuildingEntityElementWidget):
 
 class ConceitBubble(TextEditBubbleWidget):
     def __init__(self, conceit: WorldConceit, parent=None):
-        super().__init__(parent)
+        super().__init__(parent, titleEditable=True, titleMaxWidth=150)
         self.conceit = conceit
 
         self._title.setIcon(IconRegistry.from_name(self.conceit.icon, '#510442'))
         self._title.setText(self.conceit.name)
+        self._textedit.setPlaceholderText('An element of wonder that deviates from our world')
+        self._textedit.setStyleSheet('''
+            QTextEdit {
+                border: 1px solid #dabfa7;
+                border-radius: 6px;
+                padding: 4px;
+                background-color: #e3d0bd;
+            }
+        ''')
 
 
 class ConceitsElementEditor(WorldBuildingEntityElementWidget):
     def __init__(self, novel: Novel, element: WorldBuildingEntityElement, parent=None):
         super().__init__(novel, element, parent)
 
-        self._wdgEditor = frame(self)
         self._wdgToolbar = QWidget()
-        self._wdgDisplay = QWidget()
-        vbox(self._wdgEditor, 0)
         hbox(self._wdgToolbar)
-        flow(self._wdgDisplay)
+        self._wdgEditor = frame(self)
+        flow(self._wdgEditor, 10, 8)
+        sp(self._wdgEditor).v_max()
 
         self._btnToggleTree = tool_btn(IconRegistry.from_name('mdi.file-tree-outline', '#510442'), transparent_=True,
                                        checkable=True)
@@ -705,16 +713,14 @@ class ConceitsElementEditor(WorldBuildingEntityElementWidget):
 
         self._wdgToolbar.layout().addWidget(self._btnToggleTree)
         self._wdgToolbar.layout().addWidget(vline())
-
         self._wdgToolbar.layout().addWidget(self._btnAddConceit)
         self._wdgToolbar.layout().addWidget(spacer())
         self._wdgToolbar.layout().addWidget(self._btnTitle)
         self._wdgToolbar.layout().addWidget(spacer())
 
-        self._wdgEditor.layout().addWidget(self._wdgToolbar)
-        self._wdgEditor.layout().addWidget(self._wdgDisplay)
-
+        self.layout().addWidget(self._wdgToolbar)
         self.layout().addWidget(self._wdgEditor)
+
         self.layout().addWidget(self.btnAdd, alignment=Qt.AlignmentFlag.AlignCenter)
         self.installEventFilter(VisibilityToggleEventFilter(self.btnAdd, self))
 
@@ -734,6 +740,11 @@ class ConceitsElementEditor(WorldBuildingEntityElementWidget):
 
         self.btnDrag.raise_()
 
+    @overrides
+    def resizeEvent(self, event: QResizeEvent) -> None:
+        super().resizeEvent(event)
+        self._wdgEditor.updateGeometry()
+
     def _showMenu(self):
         menu = MenuWidget()
         for conceitType in WorldConceitType:
@@ -747,7 +758,7 @@ class ConceitsElementEditor(WorldBuildingEntityElementWidget):
     def _addNewConceit(self, conceitType: WorldConceitType):
         conceit = WorldConceit('Conceit', type=conceitType, icon=conceitType.icon())
         bubble = ConceitBubble(conceit)
-        self._wdgDisplay.layout().addWidget(bubble)
+        self._wdgEditor.layout().addWidget(bubble)
 
 
 class SectionElementEditor(WorldBuildingEntityElementWidget):

--- a/src/main/python/plotlyst/view/widget/world/editor.py
+++ b/src/main/python/plotlyst/view/widget/world/editor.py
@@ -685,7 +685,7 @@ class ConceitsElementEditor(WorldBuildingEntityElementWidget):
         self._splitter.setChildrenCollapsible(False)
         self._splitter.setHandleWidth(10)
         self._splitter.setProperty('framed', True)
-        self._splitter.setSizes([150, 500])
+        self._splitter.setSizes([100, 500])
         self._wdgEditor.layout().addWidget(self._splitter)
 
         self._wdgTree = ConceitsTreeView(novel)

--- a/src/main/python/plotlyst/view/widget/world/editor.py
+++ b/src/main/python/plotlyst/view/widget/world/editor.py
@@ -26,7 +26,7 @@ from PyQt6.QtCore import pyqtSignal, Qt, QSize, QMimeData, QPointF, QEvent
 from PyQt6.QtGui import QTextCharFormat, QTextCursor, QFont, QResizeEvent, QMouseEvent, QColor, QIcon, QImage, \
     QShowEvent, QPixmap, QCursor, QEnterEvent
 from PyQt6.QtWidgets import QWidget, QSplitter, QLineEdit, QDialog, QGridLayout, QSlider, QToolButton, QButtonGroup, \
-    QLabel, QToolTip
+    QLabel, QToolTip, QSpacerItem, QSizePolicy
 from overrides import overrides
 from qthandy import vspacer, clear_layout, transparent, vbox, margins, hbox, sp, retain_when_hidden, decr_icon, pointy, \
     grid, flow, spacer, line, incr_icon, gc, translucent, incr_font, vline, bold
@@ -775,12 +775,13 @@ class ConceitsElementEditor(WorldBuildingEntityElementWidget):
 
     def _initBubble(self, conceit: WorldConceit) -> ConceitBubble:
         bubble = ConceitBubble(conceit)
-        bubble.nameEdited.connect(partial(self._conceitNameChanged, conceit))
+        bubble.nameEdited.connect(partial(self._conceitChanged, conceit))
+        bubble.iconChanged.connect(partial(self._conceitChanged, conceit))
         bubble.textChanged.connect(self.save)
         bubble.removed.connect(partial(self._conceitRemoved, bubble))
         return bubble
 
-    def _conceitNameChanged(self, conceit: WorldConceit):
+    def _conceitChanged(self, conceit: WorldConceit):
         self._wdgTree.updateItem(conceit)
         self.save()
 
@@ -793,6 +794,16 @@ class ConceitsElementEditor(WorldBuildingEntityElementWidget):
 
     def _conceitSelected(self, conceit: WorldConceit):
         clear_layout(self._wdgDisplay)
+
+        bubble = self._initBubble(conceit)
+        self._wdgDisplay.layout().addWidget(bubble)
+        self._wdgDisplay.layout().addItem(QSpacerItem(0, 5, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Maximum))
+        if conceit.children:
+            lbl = label('Subtypes', underline=True)
+            self._wdgDisplay.layout().addWidget(lbl)
+            self._wdgDisplay.layout().addItem(
+                QSpacerItem(0, 5, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Maximum))
+
         for conceit in conceit.children:
             bubble = self._initBubble(conceit)
             self._wdgDisplay.layout().addWidget(bubble)

--- a/src/main/python/plotlyst/view/widget/world/editor.py
+++ b/src/main/python/plotlyst/view/widget/world/editor.py
@@ -51,7 +51,7 @@ from plotlyst.view.style.text import apply_text_color
 from plotlyst.view.widget.button import DotsMenuButton
 from plotlyst.view.widget.display import Icon, PopupDialog, DotsDragIcon
 from plotlyst.view.widget.input import AutoAdjustableTextEdit, AutoAdjustableLineEdit, MarkdownPopupTextEditorToolbar, \
-    SearchField, TextEditBubbleWidget
+    SearchField
 from plotlyst.view.widget.timeline import TimelineWidget, BackstoryCard, TimelineTheme
 from plotlyst.view.widget.utility import IconSelectorDialog
 from plotlyst.view.widget.world._topics import ecological_topics, cultural_topics, historical_topics, \
@@ -59,7 +59,7 @@ from plotlyst.view.widget.world._topics import ecological_topics, cultural_topic
     fantastic_topics, nefarious_topics, environmental_topics, ecology_topic, culture_topic, history_topic, \
     language_topic, technology_topic, economy_topic, infrastructure_topic, religion_topic, fantasy_topic, \
     villainy_topic, environment_topic
-from plotlyst.view.widget.world.conceit import ConceitsTreeView
+from plotlyst.view.widget.world.conceit import ConceitsTreeView, ConceitBubble
 from plotlyst.view.widget.world.glossary import GlossaryTextBlockHighlighter, GlossaryTextBlockData
 from plotlyst.view.widget.world.milieu import LocationsTreeView
 
@@ -673,31 +673,6 @@ class TimelineElementEditor(WorldBuildingEntityElementWidget):
         self.btnDrag.raise_()
 
 
-class ConceitBubble(TextEditBubbleWidget):
-    nameEdited = pyqtSignal()
-
-    def __init__(self, conceit: WorldConceit, parent=None):
-        super().__init__(parent, titleEditable=True, titleMaxWidth=150)
-        self.conceit = conceit
-
-        self._title.setIcon(IconRegistry.from_name(self.conceit.icon, '#510442'))
-        self._title.setText(self.conceit.name)
-        self._title.lineEdit.textEdited.connect(self._titleEdited)
-        self._textedit.setPlaceholderText('An element of wonder that deviates from our world')
-        self._textedit.setStyleSheet('''
-            QTextEdit {
-                border: 1px solid #dabfa7;
-                border-radius: 6px;
-                padding: 4px;
-                background-color: #e3d0bd;
-            }
-        ''')
-
-    def _titleEdited(self, text: str):
-        self.conceit.name = text
-        self.nameEdited.emit()
-
-
 class ConceitsElementEditor(WorldBuildingEntityElementWidget):
     def __init__(self, novel: Novel, element: WorldBuildingEntityElement, parent=None):
         super().__init__(novel, element, parent)
@@ -797,6 +772,7 @@ class ConceitsElementEditor(WorldBuildingEntityElementWidget):
     def _initBubble(self, conceit: WorldConceit) -> ConceitBubble:
         bubble = ConceitBubble(conceit)
         bubble.nameEdited.connect(partial(self._conceitNameChanged, conceit))
+        bubble.textChanged.connect(self.save)
         return bubble
 
     def _conceitNameChanged(self, conceit: WorldConceit):

--- a/src/main/python/plotlyst/view/widget/world/milieu.py
+++ b/src/main/python/plotlyst/view/widget/world/milieu.py
@@ -76,7 +76,6 @@ class LocationNode(ItemBasedNode):
 
     @overrides
     def _iconChanged(self, iconName: str, iconColor: str):
-        print('icon changed')
         pass
         # self._novel.icon = iconName
         # self._novel.icon_color = iconColor


### PR DESCRIPTION
- [x] menu action
- [x] domain block type
- [x] base widget and factory
- [x] conceits types domain
- [x] conceits domain per world
- [x] addbtn
- [x] menu
- [x] add conceit bubble
- [x] store top conceits
- [x] restore bubble
- [x] root node
- [x] type node
- [x] display current conceits in tree
- [x] tree theme settings
- [x] splitter frame
- [x] splitter def settings
- [x] toggle tree
- [x] add new top level
- [x] remove top level
- [x] fade in bubble
- [x] add child
- [x] remove child
- [x] select conceit and display children
- [x] select root and display top level
- [x] select type and top level of those type
- [x] select root
- [x] select root by default
- [x] edit conceit title
- [x] reflect conceit change in tree
- [x] edit conceit text
- [x] change conceit icon
- [x] sort by type when root is selected
- [x] delete from tree
- [x] default icon