### PR TITLE
Scene display improvements

### DIFF
--- a/src/main/python/plotlyst/core/client.py
+++ b/src/main/python/plotlyst/core/client.py
@@ -190,7 +190,9 @@ class SceneInfo:
     structure: List[SceneStructureItem] = field(default_factory=list)
     questions: List[SceneReaderQuestion] = field(default_factory=list)
     info: List[SceneReaderInformation] = field(default_factory=list)
-    progress: int = 0
+    progress: int = field(default=0, metadata=config(exclude=exclude_if_empty))
+    plot_pos_progress: int = field(default=0, metadata=config(exclude=exclude_if_empty))
+    plot_neg_progress: int = field(default=0, metadata=config(exclude=exclude_if_empty))
     functions: SceneFunctions = field(default_factory=SceneFunctions)
 
 
@@ -225,7 +227,7 @@ class NovelInfo:
     locations: List[Location] = field(default_factory=default_locations)
     board: Board = field(default_factory=Board)
     manuscript_goals: ManuscriptGoals = field(default_factory=ManuscriptGoals)
-    events_map: Diagram = field(default=None, metadata=config(exclude=exclude_if_empty))
+    events_map: Optional[Diagram] = field(default=None, metadata=config(exclude=exclude_if_empty))
     character_networks: List[Diagram] = field(default_factory=default_character_networks)
     manuscript_progress: Dict[str, DocumentProgress] = field(default_factory=dict,
                                                              metadata=config(exclude=exclude_if_empty))
@@ -590,7 +592,8 @@ class JsonClient:
                               document=info.document, manuscript=info.manuscript, drive=info.drive,
                               purpose=info.purpose, outcome=info.outcome, story_elements=info.story_elements,
                               structure=info.structure, questions=info.questions, info=info.info,
-                              progress=info.progress, functions=info.functions)
+                              progress=info.progress, plot_pos_progress=info.plot_pos_progress,
+                              plot_neg_progress=info.plot_neg_progress, functions=info.functions)
                 scenes.append(scene)
 
         tag_types = novel_info.tag_types
@@ -722,6 +725,7 @@ class JsonClient:
                          drive=scene.drive, purpose=scene.purpose, outcome=scene.outcome,
                          story_elements=scene.story_elements,
                          structure=scene.structure, questions=scene.questions, info=scene.info, progress=scene.progress,
+                         plot_pos_progress=scene.plot_pos_progress, plot_neg_progress=scene.plot_neg_progress,
                          functions=scene.functions)
         self.__persist_info(self.scenes_dir(novel), info)
 

--- a/src/main/python/plotlyst/core/domain.py
+++ b/src/main/python/plotlyst/core/domain.py
@@ -3732,6 +3732,7 @@ class NovelSetting(Enum):
     Management = 'management'
     SCENE_CARD_POV = 'scene_card_pov'
     SCENE_CARD_PURPOSE = 'scene_card_purpose'
+    SCENE_CARD_PLOT_PROGRESS = 'scene_card_plot_progress'
     SCENE_CARD_STAGE = 'scene_card_stage'
     SCENE_CARD_MIDDLE = 'scene_card_middle_display'
     SCENE_CARD_WIDTH = 'scene_card_width'

--- a/src/main/python/plotlyst/core/domain.py
+++ b/src/main/python/plotlyst/core/domain.py
@@ -3752,6 +3752,7 @@ class NovelSetting(Enum):
     SCENE_TABLE_PURPOSE = 'scene_table_purpose'
     SCENE_TABLE_CHARACTERS = 'scene_table_characters'
     SCENE_TABLE_STORYLINES = 'scene_table_storylines'
+    SCENE_TABLE_PLOT_PROGRESS = 'scene_table_plot_progress'
     Character_enneagram = 'character_enneagram'
     Character_mbti = 'character_mbti'
     Character_love_style = 'character_love_style'

--- a/src/main/python/plotlyst/core/domain.py
+++ b/src/main/python/plotlyst/core/domain.py
@@ -1985,7 +1985,9 @@ class Scene:
     structure: List[SceneStructureItem] = field(default_factory=list)
     questions: List[SceneReaderQuestion] = field(default_factory=list)
     info: List[SceneReaderInformation] = field(default_factory=list)
-    progress: int = 0
+    progress: int = field(default=0, metadata=config(exclude=exclude_if_empty))
+    plot_pos_progress: int = field(default=0, metadata=config(exclude=exclude_if_empty))
+    plot_neg_progress: int = field(default=0, metadata=config(exclude=exclude_if_empty))
     functions: SceneFunctions = field(default_factory=SceneFunctions)
 
     def beat(self, novel: 'Novel') -> Optional[StoryBeat]:
@@ -2044,6 +2046,16 @@ class Scene:
 
     def title_or_index(self, novel: 'Novel') -> str:
         return self.title if self.title else f'Scene {novel.scenes.index(self) + 1}'
+
+    def calculate_plot_progress(self):
+        self.plot_pos_progress = 0
+        self.plot_neg_progress = 0
+        for ref in self.plot_values:
+            if ref.data.charge:
+                if ref.data.charge > 0:
+                    self.plot_pos_progress = max(self.plot_pos_progress, ref.data.charge)
+                else:
+                    self.plot_neg_progress = min(self.plot_neg_progress, ref.data.charge)
 
     def __is_outcome(self, expected) -> bool:
         if self.outcome and self.outcome == expected:

--- a/src/main/python/plotlyst/model/scenes_model.py
+++ b/src/main/python/plotlyst/model/scenes_model.py
@@ -62,11 +62,12 @@ class ScenesTableModel(AbstractHorizontalHeaderBasedTableModel, BaseScenesTableM
     ColType = 4
     ColTime = 5
     ColArc = 6
-    ColSynopsis = 7
+    ColProgress = 7
+    ColSynopsis = 8
 
     def __init__(self, novel: Novel, parent=None):
         self.novel = novel
-        _headers = [''] * 8
+        _headers = [''] * 9
         _headers[self.ColTitle] = 'Title'
         _headers[self.ColType] = 'Type'
         _headers[self.ColPov] = 'POV'
@@ -74,6 +75,7 @@ class ScenesTableModel(AbstractHorizontalHeaderBasedTableModel, BaseScenesTableM
         _headers[self.ColCharacters] = 'Characters'
         _headers[self.ColTime] = 'Day'
         _headers[self.ColArc] = 'Arc'
+        _headers[self.ColProgress] = ''
         _headers[self.ColSynopsis] = 'Synopsis'
         super().__init__(_headers, parent)
         self._relax_colors = False
@@ -136,6 +138,11 @@ class ScenesTableModel(AbstractHorizontalHeaderBasedTableModel, BaseScenesTableM
                     return self._character_insight_icon
                 elif scene.purpose == ScenePurposeType.Exposition:
                     return self._exposition_icon
+            elif index.column() == self.ColProgress:
+                if scene.plot_pos_progress or scene.plot_neg_progress:
+                    return IconRegistry.plot_charge_icon(scene.plot_pos_progress, scene.plot_neg_progress)
+                elif scene.progress:
+                    return IconRegistry.charge_icon(scene.progress)
             elif index.column() == self.ColPov:
                 if scene.pov:
                     return avatars.avatar(scene.pov)

--- a/src/main/python/plotlyst/view/common.py
+++ b/src/main/python/plotlyst/view/common.py
@@ -36,7 +36,6 @@ from PyQt6.QtWidgets import QWidget, QSizePolicy, QColorDialog, QAbstractItemVie
     QLabel, QGraphicsObject, QTextEdit
 from fbs_runtime import platform
 from overrides import overrides
-from qtanim import fade_out
 from qthandy import hbox, vbox, margins, gc, transparent, spacer, sp, pointy, incr_font
 from qthandy.filter import DisabledClickEventFilter
 
@@ -403,7 +402,7 @@ def fade_out_and_gc(parent: QWidget, widget: QWidget, duration: int = 200, teard
             teardown()
 
     widget.setDisabled((True))
-    anim = fade_out(widget, duration)
+    anim = qtanim.fade_out(widget, duration)
     anim.finished.connect(destroy)
 
 
@@ -633,6 +632,17 @@ def calculate_resized_dimensions(width: int, height: int, max_size: int = 512):
 
 def fade_in(wdg: QWidget):
     qtanim.fade_in(wdg, duration=150, teardown=lambda: wdg.setGraphicsEffect(None))
+
+
+def fade_out(wdg: QWidget):
+    qtanim.fade_out(wdg, duration=150, teardown=lambda: wdg.setGraphicsEffect(None))
+
+
+def fade(wdg: QWidget, visible: bool):
+    if visible:
+        fade_in(wdg)
+    else:
+        fade_out(wdg)
 
 
 def dominant_color(pixmap: QPixmap) -> QColor:

--- a/src/main/python/plotlyst/view/icons.py
+++ b/src/main/python/plotlyst/view/icons.py
@@ -628,6 +628,16 @@ class IconRegistry:
             return IconRegistry.from_name('mdi.chevron-triple-down', '#9d0208')
 
     @staticmethod
+    def plot_charge_icon(pos_charge: int, neg_charge: int) -> QIcon:
+        if pos_charge and pos_charge == abs(neg_charge):
+            return IconRegistry.trade_off_charge_icon(pos_charge)
+
+        if pos_charge > abs(neg_charge):
+            return IconRegistry.charge_icon(pos_charge)
+        else:
+            return IconRegistry.charge_icon(neg_charge)
+
+    @staticmethod
     def trade_off_charge_icon(charge: int = 1) -> QIcon:
         color = '#832161'
         if charge == 0:

--- a/src/main/python/plotlyst/view/scenes_view.py
+++ b/src/main/python/plotlyst/view/scenes_view.py
@@ -65,7 +65,7 @@ from plotlyst.view.widget.novel import StoryStructureSelectorMenu
 from plotlyst.view.widget.progress import SceneStageProgressCharts
 from plotlyst.view.widget.scene.story_map import StoryMap, StoryMapDisplayMode
 from plotlyst.view.widget.scenes import SceneFilterWidget, \
-    ScenesPreferencesWidget, ScenesDistributionWidget
+    ScenesPreferencesWidget, ScenesDistributionWidget, ScenePreferencesTabType
 from plotlyst.view.widget.structure.selector import ActSelectorButtons
 from plotlyst.view.widget.structure.timeline import StoryStructureTimelineWidget
 from plotlyst.view.widget.tree import TreeSettings
@@ -235,6 +235,7 @@ class ScenesOutlineView(AbstractNovelView):
         self.ui.btnPreferences.setIcon(IconRegistry.preferences_icon())
         self.prefs_widget = ScenesPreferencesWidget(self.novel)
         self.prefs_widget.settingToggled.connect(self._scene_prefs_toggled)
+        self.prefs_widget.tabChanged.connect(self._scene_prefs_tab_changed)
         self.prefs_widget.cardWidthChanged.connect(self._scene_card_width_changed)
         self.prefs_widget.cardRatioChanged.connect(self._scene_card_ratio_changed)
         self.ui.cards.setCardsWidth(
@@ -817,6 +818,12 @@ class ScenesOutlineView(AbstractNovelView):
             self.ui.cards.setSetting(setting, toggled)
         elif setting.scene_table_setting():
             self._toggle_table_columns(self._default_columns())
+
+    def _scene_prefs_tab_changed(self, tab_type: ScenePreferencesTabType):
+        if tab_type == ScenePreferencesTabType.CARDS:
+            self.ui.btnCardsView.setChecked(True)
+        elif tab_type == ScenePreferencesTabType.TABLE:
+            self.ui.btnTableView.setChecked(True)
 
     def _scene_card_width_changed(self, width: int):
         self.novel.prefs.settings[NovelSetting.SCENE_CARD_WIDTH.value] = width

--- a/src/main/python/plotlyst/view/scenes_view.py
+++ b/src/main/python/plotlyst/view/scenes_view.py
@@ -155,6 +155,7 @@ class ScenesOutlineView(AbstractNovelView):
         self.ui.tblScenes.setColumnWidth(ScenesTableModel.ColCharacters, 170)
         self.ui.tblScenes.setColumnWidth(ScenesTableModel.ColType, 55)
         self.ui.tblScenes.setColumnWidth(ScenesTableModel.ColPov, 60)
+        self.ui.tblScenes.setColumnWidth(ScenesTableModel.ColProgress, 55)
         self.ui.tblScenes.setColumnWidth(ScenesTableModel.ColSynopsis, 400)
         self.ui.tblScenes.setItemDelegate(ScenesViewDelegate())
         self.ui.tblScenes.hideColumn(ScenesTableModel.ColTime)
@@ -845,6 +846,8 @@ class ScenesOutlineView(AbstractNovelView):
             default_columns.append(ScenesTableModel.ColCharacters)
         if self.novel.prefs.toggled(NovelSetting.SCENE_TABLE_PURPOSE):
             default_columns.append(ScenesTableModel.ColType)
+        if self.novel.prefs.toggled(NovelSetting.SCENE_TABLE_PLOT_PROGRESS):
+            default_columns.append(ScenesTableModel.ColProgress)
 
         default_columns.append(ScenesTableModel.ColSynopsis)
 

--- a/src/main/python/plotlyst/view/widget/cards.py
+++ b/src/main/python/plotlyst/view/widget/cards.py
@@ -218,7 +218,7 @@ class SceneCard(Ui_SceneCard, Card):
         self.lblType.setVisible(self.novel.prefs.toggled(NovelSetting.SCENE_CARD_PURPOSE))
         self.btnPlotProgress.setVisible(self.novel.prefs.toggled(NovelSetting.SCENE_CARD_PLOT_PROGRESS))
 
-        incr_icon(self.btnPlotProgress, 2)
+        incr_icon(self.btnPlotProgress, 4)
 
         self.repo = RepositoryPersistenceManager.instance()
 
@@ -242,8 +242,13 @@ class SceneCard(Ui_SceneCard, Card):
         else:
             self.lblType.clear()
 
-        if self.scene.progress != 0:
+        if self.scene.plot_pos_progress or self.scene.plot_neg_progress:
+            self.btnPlotProgress.setIcon(
+                IconRegistry.plot_charge_icon(self.scene.plot_pos_progress, self.scene.plot_neg_progress))
+        elif self.scene.progress:
             self.btnPlotProgress.setIcon(IconRegistry.charge_icon(self.scene.progress))
+        else:
+            self.btnPlotProgress.setIcon(QIcon())
 
         self.btnStage.setScene(self.scene, self.novel)
 

--- a/src/main/python/plotlyst/view/widget/cards.py
+++ b/src/main/python/plotlyst/view/widget/cards.py
@@ -35,6 +35,7 @@ from plotlyst.core.domain import Character, Scene, Novel, NovelSetting, CardSize
 from plotlyst.core.help import enneagram_help, mbti_help
 from plotlyst.service.cache import acts_registry
 from plotlyst.service.persistence import RepositoryPersistenceManager
+from plotlyst.view.common import fade, fade_in, fade_out
 from plotlyst.view.generated.character_card_ui import Ui_CharacterCard
 from plotlyst.view.generated.scene_card_ui import Ui_SceneCard
 from plotlyst.view.icons import IconRegistry, set_avatar, avatars
@@ -277,21 +278,21 @@ class SceneCard(Ui_SceneCard, Card):
 
     def setSetting(self, setting: NovelSetting, value: Any):
         if setting == NovelSetting.SCENE_CARD_POV:
-            self.btnPov.setVisible(value)
+            # self.btnPov.setVisible(value)
+            fade(self.btnPov, value)
         elif setting == NovelSetting.SCENE_CARD_PURPOSE:
-            self.lblType.setVisible(value)
+            fade(self.lblType, value)
         elif setting == NovelSetting.SCENE_CARD_STAGE:
             self._stageVisible = value
             if self._stageVisible:
                 if self.btnStage.stageOk():
-                    self.btnStage.setVisible(True)
+                    fade_in(self.btnStage)
             else:
-                self.btnStage.setHidden(True)
+                fade_out(self.btnStage)
 
     @overrides
     def enterEvent(self, event: QEvent) -> None:
         super(SceneCard, self).enterEvent(event)
-        self.wdgCharacters.setEnabled(True)
         if self._stageVisible:
             self.btnStage.setVisible(True)
 

--- a/src/main/python/plotlyst/view/widget/cards.py
+++ b/src/main/python/plotlyst/view/widget/cards.py
@@ -81,7 +81,6 @@ class Card(QFrame):
         color.setAlpha(175)
         qtanim.glow(self, color=color, radius=0, startRadius=12, reverseAnimation=False,
                     teardown=lambda: self.setGraphicsEffect(None))
-        super().leaveEvent(event)
 
     @overrides
     def mouseReleaseEvent(self, event: QtGui.QMouseEvent) -> None:
@@ -297,13 +296,12 @@ class SceneCard(Ui_SceneCard, Card):
 
     @overrides
     def leaveEvent(self, event: QEvent) -> None:
+        super().leaveEvent(event)
         self.wdgCharacters.setEnabled(False)
         if not self._stageVisible:
             self.btnStage.setHidden(True)
         elif not self.btnStage.stageOk() and not self.btnStage.menu().isVisible():
             self.btnStage.setHidden(True)
-
-        super().leaveEvent(event)
 
     @overrides
     def showEvent(self, event: QtGui.QShowEvent) -> None:

--- a/src/main/python/plotlyst/view/widget/cards.py
+++ b/src/main/python/plotlyst/view/widget/cards.py
@@ -77,10 +77,11 @@ class Card(QFrame):
 
     @overrides
     def leaveEvent(self, event: QEvent) -> None:
-        color = QColor(PLOTLYST_SECONDARY_COLOR)
-        color.setAlpha(175)
-        qtanim.glow(self, color=color, radius=0, startRadius=12, reverseAnimation=False,
-                    teardown=lambda: self.setGraphicsEffect(None))
+        if self.isEnabled() and self.isVisible():  # protect against deletion
+            color = QColor(PLOTLYST_SECONDARY_COLOR)
+            color.setAlpha(175)
+            qtanim.glow(self, color=color, radius=0, startRadius=12, reverseAnimation=False,
+                        teardown=lambda: self.setGraphicsEffect(None))
 
     @overrides
     def mouseReleaseEvent(self, event: QtGui.QMouseEvent) -> None:

--- a/src/main/python/plotlyst/view/widget/cards.py
+++ b/src/main/python/plotlyst/view/widget/cards.py
@@ -30,7 +30,7 @@ from overrides import overrides
 from qthandy import clear_layout, retain_when_hidden, transparent, flow, translucent, gc
 from qthandy.filter import DragEventFilter, DropEventFilter
 
-from plotlyst.common import act_color, PLOTLYST_TERTIARY_COLOR, PLOTLYST_SECONDARY_COLOR
+from plotlyst.common import act_color, PLOTLYST_SECONDARY_COLOR
 from plotlyst.core.domain import Character, Scene, Novel, NovelSetting, CardSizeRatio
 from plotlyst.core.help import enneagram_help, mbti_help
 from plotlyst.service.cache import acts_registry
@@ -69,8 +69,19 @@ class Card(QFrame):
 
     @overrides
     def enterEvent(self, event: QEvent) -> None:
-        qtanim.glow(self, color=QColor(PLOTLYST_TERTIARY_COLOR))
+        color = QColor(PLOTLYST_SECONDARY_COLOR)
+        color.setAlpha(175)
+        qtanim.glow(self, color=color, radius=12, reverseAnimation=False)
+
         self.cursorEntered.emit()
+
+    @overrides
+    def leaveEvent(self, event: QEvent) -> None:
+        color = QColor(PLOTLYST_SECONDARY_COLOR)
+        color.setAlpha(175)
+        qtanim.glow(self, color=color, radius=0, startRadius=12, reverseAnimation=False,
+                    teardown=lambda: self.setGraphicsEffect(None))
+        super().leaveEvent(event)
 
     @overrides
     def mouseReleaseEvent(self, event: QtGui.QMouseEvent) -> None:
@@ -291,6 +302,8 @@ class SceneCard(Ui_SceneCard, Card):
             self.btnStage.setHidden(True)
         elif not self.btnStage.stageOk() and not self.btnStage.menu().isVisible():
             self.btnStage.setHidden(True)
+
+        super().leaveEvent(event)
 
     @overrides
     def showEvent(self, event: QtGui.QShowEvent) -> None:

--- a/src/main/python/plotlyst/view/widget/labels.py
+++ b/src/main/python/plotlyst/view/widget/labels.py
@@ -110,6 +110,7 @@ class CharacterAvatarLabel(QToolButton):
         super(CharacterAvatarLabel, self).__init__(parent)
         transparent(self)
         self.setIcon(avatars.avatar(character))
+        self.setToolTip(character.name)
         self.setIconSize(QSize(size, size))
 
 

--- a/src/main/python/plotlyst/view/widget/scene/editor.py
+++ b/src/main/python/plotlyst/view/widget/scene/editor.py
@@ -1670,22 +1670,16 @@ class SceneProgressEditor(ProgressEditor):
         self._chargeEnabled = True
         self._charge = 0
         self._altCharge = 0
-        posCharge = 0
-        negCharge = 0
-        for ref in self._scene.plot_values:
-            if ref.data.charge:
-                self._chargeEnabled = False
-                if ref.data.charge > 0:
-                    posCharge = max(posCharge, ref.data.charge)
-                else:
-                    negCharge = min(negCharge, ref.data.charge)
+        self._scene.calculate_plot_progress()
+        if self._scene.plot_pos_progress or self._scene.plot_neg_progress:
+            self._chargeEnabled = False
 
-        if abs(negCharge) > posCharge:
-            self._charge = negCharge
-            self._altCharge = posCharge
+        if abs(self._scene.plot_neg_progress) > self._scene.plot_pos_progress:
+            self._charge = self._scene.plot_neg_progress
+            self._altCharge = self._scene.plot_pos_progress
         else:
-            self._charge = posCharge
-            self._altCharge = negCharge
+            self._charge = self._scene.plot_pos_progress
+            self._altCharge = self._scene.plot_neg_progress
 
         super().refresh()
 

--- a/src/main/python/plotlyst/view/widget/scene/functions.py
+++ b/src/main/python/plotlyst/view/widget/scene/functions.py
@@ -90,13 +90,13 @@ class _StorylineAssociatedFunctionWidget(PrimarySceneFunctionWidget):
     @overrides
     def enterEvent(self, event: QEnterEvent) -> None:
         super().enterEvent(event)
-        if self._plotRef:
+        if self._plotRef and not self._plotRef.data.charge:
             fade_in(self._btnProgress)
 
     @overrides
     def leaveEvent(self, event: QEvent) -> None:
         super().leaveEvent(event)
-        if not self._plotRef or not self._plotRef.data.charge:
+        if not self._plotRef or not self._plotRef.data.charge and not self._progressMenu.isVisible():
             self._btnProgress.setVisible(False)
 
     def plot(self) -> Optional[Plot]:

--- a/src/main/python/plotlyst/view/widget/scene/story_map.py
+++ b/src/main/python/plotlyst/view/widget/scene/story_map.py
@@ -39,9 +39,9 @@ from plotlyst.common import RELAXED_WHITE_COLOR, WHITE_COLOR, PLOTLYST_TERTIARY_
 from plotlyst.common import truncate_string
 from plotlyst.core.domain import Scene, Novel, Plot, \
     ScenePlotReference, SceneFunction, StoryElementType
-from plotlyst.event.core import Event, EventListener
+from plotlyst.event.core import Event, EventListener, emit_event
 from plotlyst.event.handler import event_dispatchers
-from plotlyst.events import SceneOrderChangedEvent
+from plotlyst.events import SceneOrderChangedEvent, SceneChangedEvent
 from plotlyst.service.cache import acts_registry
 from plotlyst.service.persistence import RepositoryPersistenceManager
 from plotlyst.view.common import hmax, action, tool_btn, ButtonPressResizeEventFilter, fade_out_and_gc
@@ -274,11 +274,13 @@ class StoryLinesMapWidget(QWidget):
                 (func for func in self._clicked_scene.functions.primary if func.ref == plot.id), None)
             if ref_to_be_removed:
                 self._clicked_scene.plot_values.remove(ref_to_be_removed)
+                self._clicked_scene.calculate_plot_progress()
             if function_to_be_removed:
                 self._clicked_scene.functions.primary.remove(function_to_be_removed)
         RepositoryPersistenceManager.instance().update_scene(self._clicked_scene)
 
         self.update()
+        emit_event(self.novel, SceneChangedEvent(self, self._clicked_scene))
 
 
 GRID_ITEM_WIDTH: int = 190

--- a/src/main/python/plotlyst/view/widget/scenes.py
+++ b/src/main/python/plotlyst/view/widget/scenes.py
@@ -23,7 +23,7 @@ from typing import List
 from typing import Optional
 
 import qtanim
-from PyQt6.QtCore import Qt, QSize, pyqtSignal, QModelIndex, QItemSelection
+from PyQt6.QtCore import Qt, QSize, pyqtSignal, QModelIndex, QItemSelection, QTimer
 from PyQt6.QtGui import QColor
 from PyQt6.QtWidgets import QWidget, QFrame, QToolButton, QTreeView, QLabel, QTableView, \
     QAbstractItemView, QButtonGroup
@@ -350,7 +350,7 @@ class ScenesPreferencesWidget(QWidget, Ui_ScenesViewPreferences):
         self.cbTableCharacters.setChecked(self.novel.prefs.toggled(NovelSetting.SCENE_TABLE_CHARACTERS))
         self.cbTablePurpose.setChecked(self.novel.prefs.toggled(NovelSetting.SCENE_TABLE_PURPOSE))
 
-        self.cbPov.clicked.connect(partial(self.settingToggled.emit, NovelSetting.SCENE_CARD_POV))
+        self.cbPov.clicked.connect(self._cardPovClicked)
         self.cbPurpose.clicked.connect(self._cardPurposeClicked)
         self.cbPlotProgress.clicked.connect(self._cardPlotProgressClicked)
         self.cbStage.clicked.connect(partial(self.settingToggled.emit, NovelSetting.SCENE_CARD_STAGE))
@@ -382,15 +382,27 @@ class ScenesPreferencesWidget(QWidget, Ui_ScenesViewPreferences):
     def showTableTab(self):
         self.tabWidget.setCurrentWidget(self.tabTable)
 
+    def _cardPovClicked(self, checked: bool):
+        def handle():
+            self.settingToggled.emit(NovelSetting.SCENE_CARD_POV, checked)
+
+        QTimer.singleShot(150, handle)
+
     def _cardPurposeClicked(self, checked: bool):
-        if checked:
-            self.settingToggled.emit(NovelSetting.SCENE_CARD_PLOT_PROGRESS, False)
-        self.settingToggled.emit(NovelSetting.SCENE_CARD_PURPOSE, checked)
+        def handle():
+            if checked:
+                self.settingToggled.emit(NovelSetting.SCENE_CARD_PLOT_PROGRESS, False)
+            self.settingToggled.emit(NovelSetting.SCENE_CARD_PURPOSE, checked)
+
+        QTimer.singleShot(150, handle)
 
     def _cardPlotProgressClicked(self, checked: bool):
-        if checked:
-            self.settingToggled.emit(NovelSetting.SCENE_CARD_PURPOSE, False)
-        self.settingToggled.emit(NovelSetting.SCENE_CARD_PLOT_PROGRESS, checked)
+        def handle():
+            if checked:
+                self.settingToggled.emit(NovelSetting.SCENE_CARD_PURPOSE, False)
+            self.settingToggled.emit(NovelSetting.SCENE_CARD_PLOT_PROGRESS, checked)
+
+        QTimer.singleShot(150, handle)
 
     def _tabChanged(self, index: int):
         if self.tabWidget.widget(index) is self.tabCards:

--- a/src/main/python/plotlyst/view/widget/scenes.py
+++ b/src/main/python/plotlyst/view/widget/scenes.py
@@ -17,6 +17,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
+from enum import Enum
 from functools import partial
 from typing import List
 from typing import Optional
@@ -297,11 +298,17 @@ class SceneFilterWidget(QWidget):
         self.layout().addWidget(self.wdgActs, 1, 1, alignment=Qt.AlignmentFlag.AlignLeft)
 
 
+class ScenePreferencesTabType(Enum):
+    CARDS = 0
+    TABLE = 1
+
+
 class ScenesPreferencesWidget(QWidget, Ui_ScenesViewPreferences):
     DEFAULT_CARD_WIDTH: int = 175
     settingToggled = pyqtSignal(NovelSetting, bool)
     cardWidthChanged = pyqtSignal(int)
     cardRatioChanged = pyqtSignal(CardSizeRatio)
+    tabChanged = pyqtSignal(ScenePreferencesTabType)
 
     def __init__(self, novel: Novel, parent=None):
         super().__init__(parent)
@@ -360,11 +367,19 @@ class ScenesPreferencesWidget(QWidget, Ui_ScenesViewPreferences):
         set_tab_icon(self.tabWidget, self.tabCards, IconRegistry.cards_icon())
         set_tab_icon(self.tabWidget, self.tabTable, IconRegistry.table_icon())
 
+        self.tabWidget.currentChanged.connect(self._tabChanged)
+
     def showCardsTab(self):
         self.tabWidget.setCurrentWidget(self.tabCards)
 
     def showTableTab(self):
         self.tabWidget.setCurrentWidget(self.tabTable)
+
+    def _tabChanged(self, index: int):
+        if self.tabWidget.widget(index) is self.tabCards:
+            self.tabChanged.emit(ScenePreferencesTabType.CARDS)
+        elif self.tabWidget.widget(index) is self.tabTable:
+            self.tabChanged.emit(ScenePreferencesTabType.TABLE)
 
 
 class SceneNotesEditor(DocumentTextEditor):

--- a/src/main/python/plotlyst/view/widget/scenes.py
+++ b/src/main/python/plotlyst/view/widget/scenes.py
@@ -331,6 +331,7 @@ class ScenesPreferencesWidget(QWidget, Ui_ScenesViewPreferences):
         self.btnTableStorylines.setIcon(IconRegistry.storylines_icon())
         self.btnTableCharacters.setIcon(IconRegistry.character_icon())
         self.btnTablePurpose.setIcon(IconRegistry.from_name('fa5s.yin-yang'))
+        self.btnTablePlotProgress.setIcon(IconRegistry.from_name('mdi.chevron-double-up'))
 
         self.tabCards.layout().insertWidget(1, line(color='lightgrey'))
         self.tabCards.layout().insertWidget(5, wrap(line(color='lightgrey'), margin_left=10))
@@ -349,6 +350,7 @@ class ScenesPreferencesWidget(QWidget, Ui_ScenesViewPreferences):
         self.cbTableStorylines.setChecked(self.novel.prefs.toggled(NovelSetting.SCENE_TABLE_STORYLINES))
         self.cbTableCharacters.setChecked(self.novel.prefs.toggled(NovelSetting.SCENE_TABLE_CHARACTERS))
         self.cbTablePurpose.setChecked(self.novel.prefs.toggled(NovelSetting.SCENE_TABLE_PURPOSE))
+        self.cbTablePlotProgress.setChecked(self.novel.prefs.toggled(NovelSetting.SCENE_TABLE_PLOT_PROGRESS))
 
         self.cbPov.clicked.connect(self._cardPovClicked)
         self.cbPurpose.clicked.connect(self._cardPurposeClicked)
@@ -359,6 +361,8 @@ class ScenesPreferencesWidget(QWidget, Ui_ScenesViewPreferences):
         self.cbTableStorylines.clicked.connect(partial(self.settingToggled.emit, NovelSetting.SCENE_TABLE_STORYLINES))
         self.cbTableCharacters.clicked.connect(partial(self.settingToggled.emit, NovelSetting.SCENE_TABLE_CHARACTERS))
         self.cbTablePurpose.clicked.connect(partial(self.settingToggled.emit, NovelSetting.SCENE_TABLE_PURPOSE))
+        self.cbTablePlotProgress.clicked.connect(
+            partial(self.settingToggled.emit, NovelSetting.SCENE_TABLE_PLOT_PROGRESS))
 
         self.sliderCards.setValue(self.novel.prefs.setting(NovelSetting.SCENE_CARD_WIDTH, self.DEFAULT_CARD_WIDTH))
         self.sliderCards.valueChanged.connect(self.cardWidthChanged)

--- a/ui/scene_card.ui
+++ b/ui/scene_card.ui
@@ -323,6 +323,29 @@
           </property>
          </widget>
         </item>
+        <item alignment="Qt::AlignLeft">
+         <widget class="QToolButton" name="btnPlotProgress">
+          <property name="text">
+           <string/>
+          </property>
+          <property name="transparent" stdset="0">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
         <item>
          <widget class="SceneStageButton" name="btnStage"/>
         </item>

--- a/ui/scenes_view_preferences_widget.ui
+++ b/ui/scenes_view_preferences_widget.ui
@@ -601,6 +601,43 @@
         </layout>
        </item>
        <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_17">
+         <property name="leftMargin">
+          <number>10</number>
+         </property>
+         <item>
+          <widget class="QToolButton" name="btnTablePlotProgress">
+           <property name="text">
+            <string/>
+           </property>
+           <property name="transparent" stdset="0">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_16">
+           <property name="text">
+            <string>Plot progress</string>
+           </property>
+          </widget>
+         </item>
+         <item alignment="Qt::AlignRight">
+          <widget class="Toggle" name="cbTablePlotProgress">
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
         <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/ui/scenes_view_preferences_widget.ui
+++ b/ui/scenes_view_preferences_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>421</width>
-    <height>389</height>
+    <width>267</width>
+    <height>432</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -32,7 +32,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tabCards">
       <property name="relaxe-white-bg" stdset="0">
@@ -112,43 +112,6 @@
         </layout>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_4">
-         <property name="leftMargin">
-          <number>10</number>
-         </property>
-         <item>
-          <widget class="QToolButton" name="btnPurpose">
-           <property name="text">
-            <string/>
-           </property>
-           <property name="transparent" stdset="0">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="label_4">
-           <property name="text">
-            <string>Purpose</string>
-           </property>
-          </widget>
-         </item>
-         <item alignment="Qt::AlignRight">
-          <widget class="Toggle" name="cbPurpose">
-           <property name="minimumSize">
-            <size>
-             <width>60</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
         <layout class="QHBoxLayout" name="horizontalLayout_7">
          <property name="leftMargin">
           <number>10</number>
@@ -172,6 +135,80 @@
          </item>
          <item alignment="Qt::AlignRight">
           <widget class="Toggle" name="cbStage">
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_15">
+         <property name="leftMargin">
+          <number>10</number>
+         </property>
+         <item>
+          <widget class="QToolButton" name="btnPurpose">
+           <property name="text">
+            <string/>
+           </property>
+           <property name="transparent" stdset="0">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_14">
+           <property name="text">
+            <string>Purpose</string>
+           </property>
+          </widget>
+         </item>
+         <item alignment="Qt::AlignRight">
+          <widget class="Toggle" name="cbPurpose">
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_16">
+         <property name="leftMargin">
+          <number>10</number>
+         </property>
+         <item>
+          <widget class="QToolButton" name="btnPlotProgress">
+           <property name="text">
+            <string/>
+           </property>
+           <property name="transparent" stdset="0">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_15">
+           <property name="text">
+            <string>Plot progress</string>
+           </property>
+          </widget>
+         </item>
+         <item alignment="Qt::AlignRight">
+          <widget class="Toggle" name="cbPlotProgress">
            <property name="minimumSize">
             <size>
              <width>60</width>


### PR DESCRIPTION
- [x] better shadow on cards
- [x] character tooltip
- [x] switch perspective from customization menu
- [x] translucent purpose icon
- [x] fade pov
- [x] fade purpose
- [x] fade stage
- [x] fade card on filter
- [x] progress toggle
- [x] exclusive with purpose
- [x] turn off purpose when progress is clicked
- [x] display simple scene progress icon
- [x] restore progress state
- [x] toggle off progress on purpose
- [x] handle 0 progress
- [x] bigger icons
- [x] review colors
- [x] delay pov setting
- [x] table column
- [x] consider storylines progress
- [x] edit progress in scene editor
- [x] edit storyline progress in editor
- [x] remove storyline associaiton in storymap
- [x] remove storyline associaiton in scene editor
- [x] plot charge btn flashing
- [x] header icon